### PR TITLE
feat: allow to enable Aurora Serverless v2 auto pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ The following table provides a sample cost breakdown for deploying this system i
 
 | AWS service | Dimensions | Cost [USD] |
 | --------------------| ----------------- | -------------------------------|
-| RDS Aurora | Postgres Serverless v2 (0.5ACU) | $43.2 |
+| RDS Aurora | Postgres Serverless v2 (0 ACU) | $0 |
 | ElastiCache | Valkey t4g.micro | $9.2 |
 | ECS (Fargate) | Dify-web 1 task running 24/7 (256CPU) | $2.7 |
 | ECS (Fargate) | Dify-api 1 task running 24/7 (1024CPU) | $10.7 |
 | ECS (Fargate) | Dify-worker 1 task running 24/7 (1024CPU) | $10.7 |
 | Application Load Balancer | ALB-hour per month | $17.5 |
 | VPC | NAT Instances t4g.nano x1 | $3.0 |
-| TOTAL | estimate per month | $97.0 |
+| TOTAL | estimate per month | $53.8 |
 
 Note that you have to pay LLM cost (e.g. Amazon Bedrock ) in addition to the above, which totally depends on your specific use case.
 

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -15,5 +15,10 @@ new DifyOnAwsStack(app, 'DifyOnAwsStack', {
   // Set Dify version
   difyImageTag: '0.9.1',
 
+  // uncomment the below for cheap configuration:
+  // isRedisMultiAz: false,
+  // cheapVpc: true,
+  // enableAuroraScalesToZero: true,
+
   // Please see DifyOnAwsStackProps in lib/dify-on-aws-stack.ts for all the available properties
 });

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -63,6 +63,12 @@ interface DifyOnAwsStackProps extends cdk.StackProps {
   isRedisMultiAz?: boolean;
 
   /**
+   *
+   * @default false
+   */
+  enableAuroraScalesToZero?: boolean;
+
+  /**
    * The image tag to deploy Dify container images (api=worker and web).
    * The images are pulled from [here](https://hub.docker.com/u/langgenius).
    *
@@ -148,6 +154,7 @@ export class DifyOnAwsStack extends cdk.Stack {
 
     const postgres = new Postgres(this, 'Postgres', {
       vpc,
+      scalesToZero: props.enableAuroraScalesToZero ?? false,
     });
 
     const redis = new Redis(this, 'Redis', { vpc, multiAz: props.isRedisMultiAz ?? true });

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -1414,14 +1414,16 @@ exports[`Snapshot test 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "CopyTagsToSnapshot": true,
-        "DBClusterParameterGroupName": "default.aurora-postgresql15",
+        "DBClusterParameterGroupName": {
+          "Ref": "PostgresParameterGroupC3694DF2",
+        },
         "DBSubnetGroupName": {
           "Ref": "PostgresClusterSubnets99BD7A61",
         },
         "DatabaseName": "main",
         "EnableHttpEndpoint": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.5",
+        "EngineVersion": "15.7",
         "MasterUserPassword": {
           "Fn::Join": [
             "",
@@ -1612,6 +1614,16 @@ exports[`Snapshot test 1`] = `
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Delete",
+    },
+    "PostgresParameterGroupC3694DF2": {
+      "Properties": {
+        "Description": "Cluster parameter group for aurora-postgresql15",
+        "Family": "aurora-postgresql15",
+        "Parameters": {
+          "idle_session_timeout": "60000",
+        },
+      },
+      "Type": "AWS::RDS::DBClusterParameterGroup",
     },
     "PostgresQuery0CustomResourcePolicy41175230": {
       "Properties": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Finally Aurora can now scale to zero!
https://aws.amazon.com/blogs/database/introducing-scaling-to-0-capacity-with-amazon-aurora-serverless-v2/

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/b2527028-9b71-46e5-baee-55342c2827de">


We set idle_session_timeout because idle connections prevents serverless v2 capacity's auto pause feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
