### PR TITLE
upgrade dify to 0.15.2

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -9,7 +9,7 @@ const props: EnvironmentProps = {
   awsRegion: 'us-west-2',
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
-  difyImageTag: '0.14.2',
+  difyImageTag: '0.15.2',
 
   // uncomment the below for cheap configuration:
   // isRedisMultiAz: false,

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -94,6 +94,7 @@ export class ApiService extends Construct {
         STORAGE_TYPE: 's3',
         S3_BUCKET_NAME: storageBucket.bucketName,
         S3_REGION: Stack.of(storageBucket).region,
+        S3_USE_AWS_MANAGED_IAM: 'true',
 
         // postgres settings. the credentials are in secrets property.
         DB_DATABASE: postgres.databaseName,
@@ -128,7 +129,7 @@ export class ApiService extends Construct {
       healthCheck: {
         command: ['CMD-SHELL', `curl -f http://localhost:${port}/health || exit 1`],
         interval: Duration.seconds(15),
-        startPeriod: Duration.seconds(30),
+        startPeriod: Duration.seconds(60),
         timeout: Duration.seconds(5),
         retries: 5,
       },
@@ -266,7 +267,13 @@ export class ApiService extends Construct {
     // https://github.com/langgenius/dify/issues/3471
     taskDefinition.taskRole.addToPrincipalPolicy(
       new PolicyStatement({
-        actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream', 'bedrock:Rerank', 'bedrock:Retrieve'],
+        actions: [
+          'bedrock:InvokeModel',
+          'bedrock:InvokeModelWithResponseStream',
+          'bedrock:Rerank',
+          'bedrock:Retrieve',
+          'bedrock:RetrieveAndGenerate',
+        ],
         resources: ['*'],
       }),
     );

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -27,6 +27,8 @@ export interface DifyOnAwsStackProps extends cdk.StackProps {
   readonly difySandboxImageTag?: string;
   readonly allowAnySyscalls?: boolean;
   readonly useCloudFront?: boolean;
+  readonly subDomain?: string;
+
   readonly cloudFrontWebAclArn?: string;
   readonly cloudFrontCertificate?: ICertificate;
 }
@@ -40,6 +42,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       difySandboxImageTag: sandboxImageTag = 'latest',
       allowAnySyscalls = false,
       useCloudFront = true,
+      subDomain = 'dify',
     } = props;
 
     let vpc: IVpc;
@@ -117,6 +120,7 @@ export class DifyOnAwsStack extends cdk.Stack {
           accessLogBucket,
           cloudFrontCertificate: props.cloudFrontCertificate,
           cloudFrontWebAclArn: props.cloudFrontWebAclArn,
+          subDomain,
         })
       : new Alb(this, 'Alb', {
           vpc,
@@ -124,6 +128,7 @@ export class DifyOnAwsStack extends cdk.Stack {
           allowedIPv6Cidrs: props.allowedIPv6Cidrs,
           hostedZone,
           accessLogBucket,
+          subDomain,
         });
 
     new ApiService(this, 'ApiService', {

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -50,6 +50,12 @@ export interface EnvironmentProps {
   domainName?: string;
 
   /**
+   * When domainName is set, your Dify app will be accessible with https://<subDomain>.<domainName>/
+   * @default 'dify'
+   */
+  subDomain?: string;
+
+  /**
    * If true, the ElastiCache Redis cluster is deployed to multiple AZs for fault tolerance.
    * It is generally recommended to enable this, but you can disable it to minimize AWS cost.
    * @default true

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1145,6 +1145,10 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Value": "us-west-2",
               },
               {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1169,7 +1173,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               ],
               "Interval": 15,
               "Retries": 5,
-              "StartPeriod": 30,
+              "StartPeriod": 60,
               "Timeout": 5,
             },
             "Image": "langgenius/dify-api:latest",
@@ -1954,6 +1958,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "bedrock:InvokeModelWithResponseStream",
                 "bedrock:Rerank",
                 "bedrock:Retrieve",
+                "bedrock:RetrieveAndGenerate",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -855,6 +855,10 @@ exports[`Snapshot test 1`] = `
                 "Value": "us-west-2",
               },
               {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -879,7 +883,7 @@ exports[`Snapshot test 1`] = `
               ],
               "Interval": 15,
               "Retries": 5,
-              "StartPeriod": 30,
+              "StartPeriod": 60,
               "Timeout": 5,
             },
             "Image": "langgenius/dify-api:latest",
@@ -1664,6 +1668,7 @@ exports[`Snapshot test 1`] = `
                 "bedrock:InvokeModelWithResponseStream",
                 "bedrock:Rerank",
                 "bedrock:Retrieve",
+                "bedrock:RetrieveAndGenerate",
               ],
               "Effect": "Allow",
               "Resource": "*",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

S3_USE_AWS_MANAGED_IAM seems now required.
Also I added subDomain option to allow to deploy mulitple dify instances in a single hosted zone,

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
