### PR TITLE
Use CloudFront by default

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -17,7 +17,6 @@ export const props: EnvironmentProps = {
   // enableAuroraScalesToZero: true,
 
   // Please see EnvironmentProps in lib/environment-props.ts for all the available properties
-  useCloudFront: false,
 };
 
 const app = new cdk.App();

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -747,6 +747,46 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       },
       "Type": "AWS::CloudFront::Distribution",
     },
+    "AlbGetCloudFrontPrefixListId0ED122F4": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AlbGetCloudFrontPrefixListIdCustomResourcePolicyB4DDE84F",
+      ],
+      "Properties": {
+        "Create": "{"service":"ec2","action":"describeManagedPrefixLists","parameters":{"Filters":[{"Name":"prefix-list-name","Values":["com.amazonaws.global.cloudfront.origin-facing"]}]},"physicalResourceId":{"id":"static"},"outputPaths":["PrefixLists.0.PrefixListId"]}",
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{"service":"ec2","action":"describeManagedPrefixLists","parameters":{"Filters":[{"Name":"prefix-list-name","Values":["com.amazonaws.global.cloudfront.origin-facing"]}]},"physicalResourceId":{"id":"static"},"outputPaths":["PrefixLists.0.PrefixListId"]}",
+      },
+      "Type": "Custom::AWS",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "AlbGetCloudFrontPrefixListIdCustomResourcePolicyB4DDE84F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ec2:DescribeManagedPrefixLists",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AlbGetCloudFrontPrefixListIdCustomResourcePolicyB4DDE84F",
+        "Roles": [
+          {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "AlbListener318AEEBA": {
       "Properties": {
         "DefaultActions": [
@@ -855,20 +895,46 @@ exports[`Snapshot test (with CloudFront) 2`] = `
     "AlbSecurityGroup433229ED": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB TestStackAlb4BAF7F63",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "from 0.0.0.0/0:80",
-            "FromPort": 80,
-            "IpProtocol": "tcp",
-            "ToPort": 80,
-          },
-        ],
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "AlbSecurityGroupfromIndirectPeer8094DF45A1": {
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "from ",
+              {
+                "Fn::GetAtt": [
+                  "AlbGetCloudFrontPrefixListId0ED122F4",
+                  "PrefixLists.0.PrefixListId",
+                ],
+              },
+              ":80",
+            ],
+          ],
+        },
+        "FromPort": 80,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": {
+          "Fn::GetAtt": [
+            "AlbGetCloudFrontPrefixListId0ED122F4",
+            "PrefixLists.0.PrefixListId",
+          ],
+        },
+        "ToPort": 80,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "AlbSecurityGrouptoTestStackApiServiceFargateServiceSecurityGroup7DD0AF445001CF7EB3A2": {
       "Properties": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We workaround the security issue by only allowing CloudFront prefix list for ALB security group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
