### PR TITLE
Allow to inject environment variables from bin/cdk.ts

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -114,7 +114,7 @@ export class ApiService extends Construct {
 
         // The sandbox service endpoint.
         CODE_EXECUTION_ENDPOINT: 'http://localhost:8194', // Fargate の task 内通信は localhost 宛,
-        
+
         ...getAdditionalEnvironmentVariables(this, 'api', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -10,6 +10,8 @@ import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { join } from 'path';
 import { IAlb } from '../alb';
 import { IRepository } from 'aws-cdk-lib/aws-ecr';
+import { getAdditionalEnvironmentVariables, getAdditionalSecretVariables } from './environment-variables';
+import { EnvironmentProps } from '../../environment-props';
 
 export interface ApiServiceProps {
   cluster: ICluster;
@@ -30,6 +32,8 @@ export interface ApiServiceProps {
   debug?: boolean;
 
   customRepository?: IRepository;
+
+  additionalEnvironmentVariables: EnvironmentProps['additionalEnvironmentVariables'];
 }
 
 export class ApiService extends Construct {
@@ -110,6 +114,8 @@ export class ApiService extends Construct {
 
         // The sandbox service endpoint.
         CODE_EXECUTION_ENDPOINT: 'http://localhost:8194', // Fargate の task 内通信は localhost 宛,
+        
+        ...getAdditionalEnvironmentVariables(this, 'api', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'log',
@@ -130,6 +136,7 @@ export class ApiService extends Construct {
         CELERY_BROKER_URL: ecs.Secret.fromSsmParameter(redis.brokerUrl),
         SECRET_KEY: ecs.Secret.fromSecretsManager(encryptionSecret),
         CODE_EXECUTION_API_KEY: ecs.Secret.fromSecretsManager(encryptionSecret), // is it ok to reuse this?
+        ...getAdditionalSecretVariables(this, 'api', props.additionalEnvironmentVariables),
       },
       healthCheck: {
         command: ['CMD-SHELL', `curl -f http://localhost:${port}/health || exit 1`],
@@ -172,6 +179,8 @@ export class ApiService extends Construct {
         // pgvector configurations
         VECTOR_STORE: 'pgvector',
         PGVECTOR_DATABASE: postgres.pgVectorDatabaseName,
+
+        ...getAdditionalEnvironmentVariables(this, 'worker', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'log',
@@ -188,6 +197,8 @@ export class ApiService extends Construct {
         REDIS_PASSWORD: ecs.Secret.fromSecretsManager(redis.secret),
         CELERY_BROKER_URL: ecs.Secret.fromSsmParameter(redis.brokerUrl),
         SECRET_KEY: ecs.Secret.fromSecretsManager(encryptionSecret),
+
+        ...getAdditionalSecretVariables(this, 'worker', props.additionalEnvironmentVariables),
       },
     });
 
@@ -232,6 +243,8 @@ export class ApiService extends Construct {
           '/run/systemd/resolve/stub-resolv.conf',
           '/run/resolvconf/resolv.conf',
         ].join(','),
+
+        ...getAdditionalEnvironmentVariables(this, 'sandbox', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'log',
@@ -239,6 +252,7 @@ export class ApiService extends Construct {
       portMappings: [{ containerPort: 8194 }],
       secrets: {
         API_KEY: ecs.Secret.fromSecretsManager(encryptionSecret),
+        ...getAdditionalSecretVariables(this, 'sandbox', props.additionalEnvironmentVariables),
       },
     });
 

--- a/lib/constructs/dify-services/environment-variables.ts
+++ b/lib/constructs/dify-services/environment-variables.ts
@@ -1,0 +1,61 @@
+import { Construct } from 'constructs';
+import { aws_ecs as ecs } from 'aws-cdk-lib';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { DifyContainerTypes, EnvironmentProps } from '../../environment-props';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+
+export const getAdditionalEnvironmentVariables = (
+  _: Construct,
+  containerType: DifyContainerTypes,
+  variables: EnvironmentProps['additionalEnvironmentVariables'],
+) => {
+  if (variables == null) {
+    return {};
+  }
+  const result: { [key: string]: string } = {};
+
+  for (const variable of variables) {
+    if (variable.targets != null && !variable.targets.includes(containerType)) {
+      continue;
+    }
+    if (typeof variable.value == 'string') {
+      result[variable.key] = variable.value;
+    }
+  }
+  return result;
+};
+
+export const getAdditionalSecretVariables = (
+  scope: Construct,
+  containerType: DifyContainerTypes,
+  variables: EnvironmentProps['additionalEnvironmentVariables'],
+) => {
+  if (variables == null) {
+    return {};
+  }
+  const result: { [key: string]: ecs.Secret } = {};
+
+  for (const variable of variables) {
+    if (variable.targets != null && !variable.targets.includes(containerType)) {
+      continue;
+    }
+    if (typeof variable.value == 'string') {
+      continue;
+    }
+    if ('parameterName' in variable.value) {
+      const { parameterName } = variable.value;
+      const parameter = StringParameter.fromStringParameterAttributes(
+        scope,
+        `Parameter-${containerType}-${parameterName}`,
+        { parameterName, forceDynamicReference: true },
+      );
+      result[variable.key] = ecs.Secret.fromSsmParameter(parameter);
+    }
+    if ('secretName' in variable.value) {
+      const { secretName, field } = variable.value;
+      const secret = Secret.fromSecretNameV2(scope, `Secret-${containerType}-${secretName}`, secretName);
+      result[variable.key] = ecs.Secret.fromSecretsManager(secret, field);
+    }
+  }
+  return result;
+};

--- a/lib/constructs/dify-services/web.ts
+++ b/lib/constructs/dify-services/web.ts
@@ -2,7 +2,9 @@ import { CpuArchitecture, FargateTaskDefinition, ICluster } from 'aws-cdk-lib/aw
 import { Construct } from 'constructs';
 import { Duration, aws_ecs as ecs } from 'aws-cdk-lib';
 import { IAlb } from '../alb';
-import { IRepository, Repository } from 'aws-cdk-lib/aws-ecr';
+import { IRepository } from 'aws-cdk-lib/aws-ecr';
+import { EnvironmentProps } from '../../environment-props';
+import { getAdditionalEnvironmentVariables, getAdditionalSecretVariables } from './environment-variables';
 
 export interface WebServiceProps {
   cluster: ICluster;
@@ -16,6 +18,8 @@ export interface WebServiceProps {
    */
   debug?: boolean;
   customRepository?: IRepository;
+
+  additionalEnvironmentVariables: EnvironmentProps['additionalEnvironmentVariables'];
 }
 
 export class WebService extends Construct {
@@ -52,6 +56,11 @@ export class WebService extends Construct {
         // https://nextjs.org/docs/pages/api-reference/next-config-js/output
         HOSTNAME: '0.0.0.0',
         PORT: port.toString(),
+
+        ...getAdditionalEnvironmentVariables(this, 'web', props.additionalEnvironmentVariables),
+      },
+      secrets: {
+        ...getAdditionalSecretVariables(this, 'web', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'log',

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -12,27 +12,12 @@ import { AlbWithCloudFront } from './constructs/alb-with-cloudfront';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { createVpc } from './constructs/vpc';
+import { EnvironmentProps } from './environment-props';
 
 /**
  * Mostly inherited from EnvironmentProps
  */
-export interface DifyOnAwsStackProps extends cdk.StackProps {
-  readonly allowedIPv4Cidrs?: string[];
-  readonly allowedIPv6Cidrs?: string[];
-  readonly useNatInstance?: boolean;
-  readonly vpcIsolated?: boolean;
-  readonly vpcId?: string;
-  readonly domainName?: string;
-  readonly isRedisMultiAz?: boolean;
-  readonly enableAuroraScalesToZero?: boolean;
-  readonly difyImageTag?: string;
-  readonly difySandboxImageTag?: string;
-  readonly allowAnySyscalls?: boolean;
-  readonly useCloudFront?: boolean;
-  readonly subDomain?: string;
-  readonly internalAlb?: boolean;
-  readonly customEcrRepositoryName?: string;
-
+export interface DifyOnAwsStackProps extends cdk.StackProps, Omit<EnvironmentProps, 'awsRegion' | 'awsAccount'> {
   readonly cloudFrontWebAclArn?: string;
   readonly cloudFrontCertificate?: ICertificate;
 }
@@ -142,6 +127,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       sandboxImageTag,
       allowAnySyscalls,
       customRepository,
+      additionalEnvironmentVariables: props.additionalEnvironmentVariables,
     });
 
     new WebService(this, 'WebService', {
@@ -149,6 +135,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       alb,
       imageTag,
       customRepository,
+      additionalEnvironmentVariables: props.additionalEnvironmentVariables,
     });
 
     new cdk.CfnOutput(this, 'DifyUrl', {

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -128,4 +128,37 @@ export interface EnvironmentProps {
    * @default Images are pulled from Docker Hub.
    */
   customEcrRepositoryName?: string;
+
+  /**
+   *
+   * @default No additional environment variables.
+   */
+  additionalEnvironmentVariables?: {
+    key: string;
+    value:
+      | string
+      | {
+          /**
+           * Use this when you want to refer to an existing Systems Manager parameter.
+           */
+          parameterName: string;
+        }
+      | {
+          /**
+           * Use this when you want to refer to an existing Secrets Manager secret.
+           */
+          secretName: string;
+          /**
+           * The name of the field with the value that you want to set as the environment variable value. Only values in JSON format are supported. If you do not specify a JSON field, then the full content of the secret is used.
+           */
+          field?: string;
+        };
+    /**
+     * The list of targets that use this environment variable.
+     * If not set, it is applied to all targets.
+     */
+    targets?: DifyContainerTypes[];
+  }[];
 }
+
+export type DifyContainerTypes = 'web' | 'api' | 'worker' | 'sandbox';

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -874,6 +874,14 @@ exports[`Snapshot test 1`] = `
                 "Name": "CODE_EXECUTION_ENDPOINT",
                 "Value": "http://localhost:8194",
               },
+              {
+                "Name": "ALL",
+                "Value": "foo",
+              },
+              {
+                "Name": "API_AND_WEB_ONLY",
+                "Value": "foo",
+              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -1053,6 +1061,36 @@ exports[`Snapshot test 1`] = `
                   "Ref": "ApiServiceEncryptionSecretF73F9ECD",
                 },
               },
+              {
+                "Name": "SECRET_ON_SM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:us-west-2:123456789012:secret:foo:bar::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SECRET_ON_SSM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:us-west-2:123456789012:parameter/foo",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -1123,6 +1161,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "PGVECTOR_DATABASE",
                 "Value": "pgvector",
+              },
+              {
+                "Name": "ALL",
+                "Value": "foo",
               },
             ],
             "Essential": true,
@@ -1281,6 +1323,36 @@ exports[`Snapshot test 1`] = `
                   "Ref": "ApiServiceEncryptionSecretF73F9ECD",
                 },
               },
+              {
+                "Name": "SECRET_ON_SM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:us-west-2:123456789012:secret:foo:bar::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SECRET_ON_SSM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:us-west-2:123456789012:parameter/foo",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -1325,6 +1397,10 @@ exports[`Snapshot test 1`] = `
                 "Name": "PYTHON_LIB_PATH",
                 "Value": "/usr/local/lib/python3.10,/usr/lib/python3.10,/usr/lib/python3,/usr/lib/x86_64-linux-gnu,/etc/ssl/certs/ca-certificates.crt,/etc/nsswitch.conf,/etc/hosts,/etc/resolv.conf,/run/systemd/resolve/stub-resolv.conf,/run/resolvconf/resolv.conf",
               },
+              {
+                "Name": "ALL",
+                "Value": "foo",
+              },
             ],
             "Essential": true,
             "Image": "langgenius/dify-sandbox:0.2.4",
@@ -1357,6 +1433,36 @@ exports[`Snapshot test 1`] = `
                 "Name": "API_KEY",
                 "ValueFrom": {
                   "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+              {
+                "Name": "SECRET_ON_SM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:us-west-2:123456789012:secret:foo:bar::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SECRET_ON_SSM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:us-west-2:123456789012:parameter/foo",
+                    ],
+                  ],
                 },
               },
             ],
@@ -1494,6 +1600,46 @@ exports[`Snapshot test 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:us-west-2:123456789012:secret:foo-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:us-west-2:123456789012:parameter/foo",
+                  ],
+                ],
               },
             },
             {
@@ -3015,6 +3161,46 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:us-west-2:123456789012:secret:foo-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:us-west-2:123456789012:parameter/foo",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -3056,6 +3242,14 @@ exports[`Snapshot test 1`] = `
                 "Name": "PORT",
                 "Value": "3000",
               },
+              {
+                "Name": "ALL",
+                "Value": "foo",
+              },
+              {
+                "Name": "API_AND_WEB_ONLY",
+                "Value": "foo",
+              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -3084,6 +3278,38 @@ exports[`Snapshot test 1`] = `
               {
                 "ContainerPort": 3000,
                 "Protocol": "tcp",
+              },
+            ],
+            "Secrets": [
+              {
+                "Name": "SECRET_ON_SM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:us-west-2:123456789012:secret:foo:bar::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SECRET_ON_SSM",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:us-west-2:123456789012:parameter/foo",
+                    ],
+                  ],
+                },
               },
             ],
           },

--- a/test/dify-on-aws.test.ts
+++ b/test/dify-on-aws.test.ts
@@ -17,6 +17,25 @@ test('Snapshot test', () => {
     domainName: 'example.com',
     allowAnySyscalls: true,
     useCloudFront: false,
+    additionalEnvironmentVariables: [
+      {
+        key: 'ALL',
+        value: 'foo',
+      },
+      {
+        key: 'API_AND_WEB_ONLY',
+        value: 'foo',
+        targets: ['api', 'web'],
+      },
+      {
+        key: 'SECRET_ON_SM',
+        value: { secretName: 'foo', field: 'bar' },
+      },
+      {
+        key: 'SECRET_ON_SSM',
+        value: { parameterName: 'foo' },
+      },
+    ],
   };
 
   // WHEN


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are multiple environmental variables that users want to configure to enable Dify features, such as Notion integration ([list of variables](https://docs.dify.ai/getting-started/install-self-hosted/environments).) This PR enables to define these environment variables in `bin/cdk.ts` and inject them to ECS task definitions of each dify container.

Users now can:

1. inject variables from string literals, SSM parameters, Secrets Manager secrets
2. select target dify container (web, api, worker, or sandbox)

Actual usage is here:

https://github.com/aws-samples/dify-self-hosted-on-aws/blob/089aeb2231027f6939361237b4abe0a7a99099d1/test/dify-on-aws.test.ts#L11-L39

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
