### PR TITLE
add validation to prevent from deployment error on ECS secret reference

### DIFF
--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -49,6 +49,19 @@ export class DifyOnAwsStack extends cdk.Stack {
       throw new Error('Without domainName, you cannot set subDomain property!');
     }
 
+    {
+      const filtered =
+        props.additionalEnvironmentVariables
+          ?.map((v) => v.value)
+          .filter((v) => typeof v != 'string' && 'secretName' in v)
+          .filter((v) => /-......$/.test(v.secretName))
+          .map((v) => v.secretName) ?? [];
+      if (filtered.length > 0) {
+        // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_secretsmanager.Secret.html#static-fromwbrsecretwbrnamewbrv2scope-id-secretname
+        throw new Error(`secretName cannot ends with a hyphen and 6 characters! ${filtered.join(', ')}`);
+      }
+    }
+
     if (!props.useCloudFront && props.domainName == null && !internalAlb) {
       cdk.Annotations.of(this).addWarningV2(
         'ALBWithoutEncryption',

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -50,12 +50,11 @@ export class DifyOnAwsStack extends cdk.Stack {
     }
 
     {
-      const filtered =
-        props.additionalEnvironmentVariables
-          ?.map((v) => v.value)
-          .filter((v) => typeof v != 'string' && 'secretName' in v)
-          .filter((v) => /-......$/.test(v.secretName))
-          .map((v) => v.secretName) ?? [];
+      const filtered = (props.additionalEnvironmentVariables ?? [])
+        .map((v) => v.value)
+        .filter((v) => typeof v != 'string' && 'secretName' in v)
+        .filter((v) => /-......$/.test(v.secretName))
+        .map((v) => v.secretName);
       if (filtered.length > 0) {
         // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_secretsmanager.Secret.html#static-fromwbrsecretwbrnamewbrv2scope-id-secretname
         throw new Error(`secretName cannot ends with a hyphen and 6 characters! ${filtered.join(', ')}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^3.4.2",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
-        "typescript": "~5.4.5"
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2136,12 +2136,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2381,6 +2383,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3944,6 +3947,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4333,6 +4337,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4690,9 +4695,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "^3.4.2",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "~5.4.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@types/aws-lambda": "^8.10.138",


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
When a secretName ends with a hyphen and 6 characters (e.g. `test-secret`), we get the below error on ECS task launch.

> ResourceInitializationError: unable to pull secrets or registry auth: execution resource retrieval failed: unable to retrieve secret from asm: service call has been retried 1 time(s): failed to fetch secret arn:aws:secretsmanager:ap-southeast-1:redact:secret:test-secret from secrets manager: AccessDeniedException: User: arn:aws:sts::redact:assumed-role/DifyOnAwsStack-WebServiceTaskExecutionRole4406CA16-redact is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:ap-southeast-1:redact:secret:test-secret because no identity-based policy allows the secretsmanager:GetSecretValue action status code: 400, 

This is because of a limitation of [`fromSecretNameV2`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_secretsmanager.Secret.html#static-fromwbrsecretwbrnamewbrv2scope-id-secretname): 

>  If your secret name ends with a hyphen and 6 characters, you should always use fromSecretCompleteArn() to avoid potential AccessDeniedException.


This PR adds a validation to detect the issue on synth.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
