### PR TITLE
allow to setup smtp configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ export const props: EnvironmentProps = {
 4. Deploy the stack by `cdk deploy` command.
 5. Now you can [import data from Notion](https://docs.dify.ai/guides/knowledge-base/create-knowledge-and-upload-documents/1.-import-text-data/1.1-import-data-from-notion).
 
+### Setup Email (SMTP) for user invitation
+
+You can let Dify send emails to invite new users or reset passwords. To enable the feature, set `setupEmail` property to `true` in `bin/cdk.ts` first. Note that you can only configure one email server (Amazon SES Identity) per `domainName` property.
+
+After a successful deployment, you have to move out from SES sandbox to send emails to non-verified addresses and domains. Please refer to the document for more details: [Request production access (Moving out of the Amazon SES sandbox)](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
+
 ## Clean up
 To avoid incurring future charges, clean up the resources you created.
 

--- a/lib/constructs/alb.ts
+++ b/lib/constructs/alb.ts
@@ -108,10 +108,10 @@ export class Alb extends Construct implements IAlb {
       deregistrationDelay: Duration.seconds(10),
       healthCheck: {
         path: healthCheckPath,
-        interval: Duration.seconds(20),
+        interval: Duration.seconds(30),
         healthyHttpCodes: '200-299,307',
         healthyThresholdCount: 2,
-        unhealthyThresholdCount: 6,
+        unhealthyThresholdCount: 10,
       },
     });
     // a condition only accepts an array with up to 5 elements

--- a/lib/constructs/email.ts
+++ b/lib/constructs/email.ts
@@ -1,0 +1,52 @@
+import { Duration, Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { User } from 'aws-cdk-lib/aws-iam';
+import { SesSmtpCredentials } from '@pepperize/cdk-ses-smtp-credentials';
+import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
+import { IHostedZone, TxtRecord } from 'aws-cdk-lib/aws-route53';
+import { EmailIdentity, Identity } from 'aws-cdk-lib/aws-ses';
+
+export interface EmailServiceProps {
+  hostedZone: IHostedZone;
+  setupSes?: boolean;
+}
+
+export class EmailService extends Construct {
+  /**
+   * contains json value {username: "the generated access key id", password: "the calculated ses smtp password"}
+   */
+  public readonly smtpCredentials: ISecret;
+  public readonly serverAddress: string;
+  public readonly serverPort: string;
+  public readonly domainName: string;
+
+  constructor(scope: Construct, id: string, props: EmailServiceProps) {
+    super(scope, id);
+
+    const { hostedZone, setupSes = true } = props;
+    const domainName = hostedZone.zoneName;
+
+    if (setupSes) {
+      new EmailIdentity(this, 'Identity', {
+        identity: Identity.publicHostedZone(hostedZone),
+        mailFromDomain: `bounce.${domainName}`,
+      });
+
+      new TxtRecord(this, 'DmarcRecord', {
+        zone: hostedZone,
+        recordName: `_dmarc.${domainName}`,
+        values: [`v=DMARC1; p=none; rua=mailto:dmarcreports@${domainName}`],
+        ttl: Duration.hours(1),
+      });
+    }
+
+    const smtpCredentials = new SesSmtpCredentials(this, 'SmtpCredentials', {});
+
+    this.smtpCredentials = smtpCredentials.secret;
+    this.serverAddress = `email-smtp.${Stack.of(this).region}.amazonaws.com`;
+    // dify seems to support tls wrapper only
+    // https://docs.aws.amazon.com/ses/latest/dg/smtp-connect.html
+    this.serverPort = '465';
+    this.domainName = domainName;
+  }
+}

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -159,6 +159,12 @@ export interface EnvironmentProps {
      */
     targets?: DifyContainerTypes[];
   }[];
+
+  /**
+   * If true, CDK configures SES and SMTP credentials using {@link domainName}.
+   * @default false
+   */
+  setupEmail?: boolean;
 }
 
 export type DifyContainerTypes = 'web' | 'api' | 'worker' | 'sandbox';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "dify-on-aws-cdk",
       "dependencies": {
+        "@pepperize/cdk-ses-smtp-credentials": "^0.3.826",
         "@types/aws-lambda": "^8.10.138",
         "aws-cdk-lib": "^2.148.0",
         "cdk-time-sleep": "^0.0.5",
@@ -1397,6 +1398,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pepperize/cdk-ses-smtp-credentials": {
+      "version": "0.3.826",
+      "resolved": "https://registry.npmjs.org/@pepperize/cdk-ses-smtp-credentials/-/cdk-ses-smtp-credentials-0.3.826.tgz",
+      "integrity": "sha512-R8M2U59T4ojRvlhiV091G77FyHTElrrV6vSKzJb82zhZHHU7DKEMI6YQvkO6qI+NVwVIOxUGUhpK+3YMeq4czw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.173.2",
+        "constructs": "^10.0.5"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@pepperize/cdk-ses-smtp-credentials": "^0.3.826",
     "@types/aws-lambda": "^8.10.138",
     "aws-cdk-lib": "^2.148.0",
     "cdk-time-sleep": "^0.0.5",

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1242,6 +1242,26 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Name": "CODE_EXECUTION_ENDPOINT",
                 "Value": "http://localhost:8194",
               },
+              {
+                "Name": "MAIL_TYPE",
+                "Value": "smtp",
+              },
+              {
+                "Name": "SMTP_SERVER",
+                "Value": "email-smtp.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "SMTP_PORT",
+                "Value": "465",
+              },
+              {
+                "Name": "SMTP_USE_TLS",
+                "Value": "true",
+              },
+              {
+                "Name": "MAIL_DEFAULT_SEND_FROM",
+                "Value": "no-reply@example.com",
+              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -1250,8 +1270,8 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "curl -f http://localhost:5001/health || exit 1",
               ],
               "Interval": 15,
-              "Retries": 5,
-              "StartPeriod": 60,
+              "Retries": 10,
+              "StartPeriod": 90,
               "Timeout": 5,
             },
             "Image": "langgenius/dify-api:latest",
@@ -1421,6 +1441,34 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                   "Ref": "ApiServiceEncryptionSecretF73F9ECD",
                 },
               },
+              {
+                "Name": "SMTP_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SMTP_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -1436,6 +1484,22 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "DEBUG",
                 "Value": "false",
+              },
+              {
+                "Name": "CONSOLE_WEB_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "CONSOLE_API_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "SERVICE_API_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "APP_WEB_URL",
+                "Value": "https://dify.example.com",
               },
               {
                 "Name": "MIGRATION_ENABLED",
@@ -1491,6 +1555,26 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "PGVECTOR_DATABASE",
                 "Value": "pgvector",
+              },
+              {
+                "Name": "MAIL_TYPE",
+                "Value": "smtp",
+              },
+              {
+                "Name": "SMTP_SERVER",
+                "Value": "email-smtp.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "SMTP_PORT",
+                "Value": "465",
+              },
+              {
+                "Name": "SMTP_USE_TLS",
+                "Value": "true",
+              },
+              {
+                "Name": "MAIL_DEFAULT_SEND_FROM",
+                "Value": "no-reply@example.com",
               },
             ],
             "Essential": true,
@@ -1647,6 +1731,34 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Name": "SECRET_KEY",
                 "ValueFrom": {
                   "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+              {
+                "Name": "SMTP_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SMTP_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+                      },
+                      ":password::",
+                    ],
+                  ],
                 },
               },
             ],
@@ -1862,6 +1974,16 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               "Effect": "Allow",
               "Resource": {
                 "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "EmailSmtpCredentialsSecretFF95C79F",
               },
             },
             {
@@ -2223,6 +2345,183 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       },
       "Type": "AWS::IAM::Role",
     },
+    "EmailDmarcRecord52AA55C0": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": "_dmarc.example.com.",
+        "ResourceRecords": [
+          ""v=DMARC1; p=none; rua=mailto:dmarcreports@example.com"",
+        ],
+        "TTL": "3600",
+        "Type": "TXT",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailIdentityCD6BD173": {
+      "Properties": {
+        "EmailIdentity": "example.com",
+        "MailFromAttributes": {
+          "MailFromDomain": "bounce.example.com",
+        },
+      },
+      "Type": "AWS::SES::EmailIdentity",
+    },
+    "EmailIdentityDkimDnsToken1AC8FBCD6": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": {
+          "Fn::GetAtt": [
+            "EmailIdentityCD6BD173",
+            "DkimDNSTokenName1",
+          ],
+        },
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "EmailIdentityCD6BD173",
+              "DkimDNSTokenValue1",
+            ],
+          },
+        ],
+        "TTL": "1800",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailIdentityDkimDnsToken2B3E721B6": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": {
+          "Fn::GetAtt": [
+            "EmailIdentityCD6BD173",
+            "DkimDNSTokenName2",
+          ],
+        },
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "EmailIdentityCD6BD173",
+              "DkimDNSTokenValue2",
+            ],
+          },
+        ],
+        "TTL": "1800",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailIdentityDkimDnsToken3063E158F": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": {
+          "Fn::GetAtt": [
+            "EmailIdentityCD6BD173",
+            "DkimDNSTokenName3",
+          ],
+        },
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "EmailIdentityCD6BD173",
+              "DkimDNSTokenValue3",
+            ],
+          },
+        ],
+        "TTL": "1800",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailIdentityMailFromMxRecord2B99574B": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": "bounce.example.com.",
+        "ResourceRecords": [
+          "10 feedback-smtp.us-west-2.amazonses.com",
+        ],
+        "TTL": "1800",
+        "Type": "MX",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailIdentityMailFromTxtRecord4B108A46": {
+      "Properties": {
+        "HostedZoneId": "DUMMY",
+        "Name": "bounce.example.com.",
+        "ResourceRecords": [
+          ""v=spf1 include:amazonses.com ~all"",
+        ],
+        "TTL": "1800",
+        "Type": "TXT",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "EmailSmtpCredentialsLambdaC8E98BEF": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "EmailSmtpCredentialsSecretFF95C79F",
+        "EmailSmtpCredentialsUserAAAE4D61",
+      ],
+      "Properties": {
+        "SecretId": {
+          "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C",
+            "Arn",
+          ],
+        },
+        "UserName": {
+          "Ref": "EmailSmtpCredentialsUserAAAE4D61",
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EmailSmtpCredentialsPolicyC27A5F90": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ses:SendRawEmail",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EmailSmtpCredentialsPolicyC27A5F90",
+        "Users": [
+          {
+            "Ref": "EmailSmtpCredentialsUserAAAE4D61",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "EmailSmtpCredentialsSecretFF95C79F": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "SES Smtp Credentials (username, password) for ",
+              {
+                "Ref": "EmailSmtpCredentialsUserAAAE4D61",
+              },
+            ],
+          ],
+        },
+        "GenerateSecretString": {},
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EmailSmtpCredentialsUserAAAE4D61": {
+      "Type": "AWS::IAM::User",
+    },
     "ExportsReader8B249524": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -2243,6 +2542,83 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       },
       "Type": "Custom::CrossRegionExportReader",
       "UpdateReplacePolicy": "Delete",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
+      "DependsOn": [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-west-2",
+          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": [
+          {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "PostgresCluster53E5BDAB": {
       "DeletionPolicy": "Delete",
@@ -3637,6 +4013,257 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D": {
+      "DependsOn": [
+        "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRoleDefaultPolicyA3895E80",
+        "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-west-2",
+          "S3Key": "681d284a27fcbbccf41227929a9c13895a5859749b289f961ca68f3b8d47d137.zip",
+        },
+        "Description": "src/provider/credentials-handler.lambda.ts",
+        "Environment": {
+          "Variables": {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerLogRetention5C8B4A91": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 30,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRoleDefaultPolicyA3895E80": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "iam:CreateAccessKey",
+                "iam:DeleteAccessKey",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "EmailSmtpCredentialsUserAAAE4D61",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "secretsmanager:PutSecretValue",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "EmailSmtpCredentialsSecretFF95C79F",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRoleDefaultPolicyA3895E80",
+        "Roles": [
+          {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C": {
+      "DependsOn": [
+        "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26",
+        "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-west-2",
+          "S3Key": "bdc104ed9cab1b5b6421713c8155f0b753380595356f710400609664d3635eca.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (TestStack/cdk-ses-smtp-credentials.CredentialsProvider/ses-smtp-credentials-provider)",
+        "Environment": {
+          "Variables": {
+            "USER_ON_EVENT_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "Handler": "framework.onEvent",
+        "Role": {
+          "Fn::GetAtt": [
+            "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventLogRetentionCD61E4D7": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 1,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26",
+        "Roles": [
+          {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
   "Rules": {

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -331,7 +331,7 @@ exports[`Snapshot test 1`] = `
     },
     "AlbApiTargetGroup4B6AF19C": {
       "Properties": {
-        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckIntervalSeconds": 30,
         "HealthCheckPath": "/health",
         "HealthyThresholdCount": 2,
         "Matcher": {
@@ -350,7 +350,7 @@ exports[`Snapshot test 1`] = `
           },
         ],
         "TargetType": "ip",
-        "UnhealthyThresholdCount": 6,
+        "UnhealthyThresholdCount": 10,
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
@@ -577,7 +577,7 @@ exports[`Snapshot test 1`] = `
     },
     "AlbWebTargetGroupC65B2BDF": {
       "Properties": {
-        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckIntervalSeconds": 30,
         "HealthCheckPath": "/",
         "HealthyThresholdCount": 2,
         "Matcher": {
@@ -596,7 +596,7 @@ exports[`Snapshot test 1`] = `
           },
         ],
         "TargetType": "ip",
-        "UnhealthyThresholdCount": 6,
+        "UnhealthyThresholdCount": 10,
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
@@ -887,8 +887,8 @@ exports[`Snapshot test 1`] = `
                 "curl -f http://localhost:5001/health || exit 1",
               ],
               "Interval": 15,
-              "Retries": 5,
-              "StartPeriod": 60,
+              "Retries": 10,
+              "StartPeriod": 90,
               "Timeout": 5,
             },
             "Image": {
@@ -1084,6 +1084,74 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "DEBUG",
                 "Value": "false",
+              },
+              {
+                "Name": "CONSOLE_WEB_URL",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "AlbC1372A32",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CONSOLE_API_URL",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "AlbC1372A32",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "SERVICE_API_URL",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "AlbC1372A32",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "APP_WEB_URL",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "AlbC1372A32",
+                          "DNSName",
+                        ],
+                      },
+                    ],
+                  ],
+                },
               },
               {
                 "Name": "MIGRATION_ENABLED",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -348,7 +348,7 @@ exports[`Snapshot test 1`] = `
     },
     "AlbApiTargetGroup4B6AF19C": {
       "Properties": {
-        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckIntervalSeconds": 30,
         "HealthCheckPath": "/health",
         "HealthyThresholdCount": 2,
         "Matcher": {
@@ -367,7 +367,7 @@ exports[`Snapshot test 1`] = `
           },
         ],
         "TargetType": "ip",
-        "UnhealthyThresholdCount": 6,
+        "UnhealthyThresholdCount": 10,
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
@@ -624,7 +624,7 @@ exports[`Snapshot test 1`] = `
     },
     "AlbWebTargetGroupC65B2BDF": {
       "Properties": {
-        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckIntervalSeconds": 30,
         "HealthCheckPath": "/",
         "HealthyThresholdCount": 2,
         "Matcher": {
@@ -643,7 +643,7 @@ exports[`Snapshot test 1`] = `
           },
         ],
         "TargetType": "ip",
-        "UnhealthyThresholdCount": 6,
+        "UnhealthyThresholdCount": 10,
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
@@ -890,8 +890,8 @@ exports[`Snapshot test 1`] = `
                 "curl -f http://localhost:5001/health || exit 1",
               ],
               "Interval": 15,
-              "Retries": 5,
-              "StartPeriod": 60,
+              "Retries": 10,
+              "StartPeriod": 90,
               "Timeout": 5,
             },
             "Image": "langgenius/dify-api:latest",
@@ -1106,6 +1106,22 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "DEBUG",
                 "Value": "false",
+              },
+              {
+                "Name": "CONSOLE_WEB_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "CONSOLE_API_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "SERVICE_API_URL",
+                "Value": "https://dify.example.com",
+              },
+              {
+                "Name": "APP_WEB_URL",
+                "Value": "https://dify.example.com",
               },
               {
                 "Name": "MIGRATION_ENABLED",

--- a/test/dify-on-aws-cf.test.ts
+++ b/test/dify-on-aws-cf.test.ts
@@ -16,6 +16,7 @@ test('Snapshot test (with CloudFront)', () => {
     difySandboxImageTag: '0.2.4',
     domainName: 'example.com',
     allowAnySyscalls: true,
+    setupEmail: true,
   };
 
   // WHEN


### PR DESCRIPTION
*Issue #, if available:*
closes #32 

*Description of changes:*

Now you can setup Amazon SES and its credentials by setting `setupEmail: true`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
