### PR TITLE
allow to use fargate on-demand capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If you set `customEcrRepositoryName` and have run the `copy-to-ecr.ts` script, p
 
 ## Cost
 
-The following table provides a sample cost breakdown for deploying this system in the us-east-1 (N. Virginia) region for one month (when deployed using cheap configuration).
+The following table provides a sample cost breakdown for deploying this system in the us-east-1 (N. Virginia) region for one month (when deployed using less expensive configuration).
 
 
 | AWS service | Dimensions | Cost [USD] |

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -11,10 +11,11 @@ export const props: EnvironmentProps = {
   // Set Dify version
   difyImageTag: '0.15.3',
 
-  // uncomment the below for cheap configuration:
+  // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,
   // useNatInstance: true,
   // enableAuroraScalesToZero: true,
+  // useFargateSpot: true,
 
   // Please see EnvironmentProps in lib/environment-props.ts for all the available properties
 };

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -36,6 +36,8 @@ export interface ApiServiceProps {
   customRepository?: IRepository;
 
   additionalEnvironmentVariables: EnvironmentProps['additionalEnvironmentVariables'];
+
+  useFargateSpot: boolean;
 }
 
 export class ApiService extends Construct {
@@ -351,11 +353,11 @@ export class ApiService extends Construct {
       capacityProviderStrategies: [
         {
           capacityProvider: 'FARGATE',
-          weight: 0,
+          weight: props.useFargateSpot ? 0 : 1,
         },
         {
           capacityProvider: 'FARGATE_SPOT',
-          weight: 1,
+          weight: props.useFargateSpot ? 1 : 0,
         },
       ],
       enableExecuteCommand: true,

--- a/lib/constructs/dify-services/web.ts
+++ b/lib/constructs/dify-services/web.ts
@@ -20,6 +20,7 @@ export interface WebServiceProps {
   customRepository?: IRepository;
 
   additionalEnvironmentVariables: EnvironmentProps['additionalEnvironmentVariables'];
+  useFargateSpot: boolean;
 }
 
 export class WebService extends Construct {
@@ -82,11 +83,11 @@ export class WebService extends Construct {
       capacityProviderStrategies: [
         {
           capacityProvider: 'FARGATE',
-          weight: 0,
+          weight: props.useFargateSpot ? 0 : 1,
         },
         {
           capacityProvider: 'FARGATE_SPOT',
-          weight: 1,
+          weight: props.useFargateSpot ? 1 : 0,
         },
       ],
       enableExecuteCommand: true,

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -33,6 +33,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       allowAnySyscalls = false,
       useCloudFront = true,
       internalAlb = false,
+      useFargateSpot = false,
       subDomain = 'dify',
     } = props;
 
@@ -153,6 +154,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       allowAnySyscalls,
       customRepository,
       additionalEnvironmentVariables: props.additionalEnvironmentVariables,
+      useFargateSpot,
     });
 
     new WebService(this, 'WebService', {
@@ -161,6 +163,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       imageTag,
       customRepository,
       additionalEnvironmentVariables: props.additionalEnvironmentVariables,
+      useFargateSpot,
     });
 
     new cdk.CfnOutput(this, 'DifyUrl', {

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -79,6 +79,13 @@ export interface EnvironmentProps {
   enableAuroraScalesToZero?: boolean;
 
   /**
+   * If enabled, Dify runs on Fargate spot capacity. Note that because Fargate spot can be interrupted,
+   * it is recommended to use the option for non-critical use case.
+   * @default false
+   */
+  useFargateSpot?: boolean;
+
+  /**
    * The image tag to deploy the Dify container images (api and web).
    * The images are pulled from [here](https://hub.docker.com/u/langgenius).
    *

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1039,11 +1039,11 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {
@@ -3717,11 +3717,11 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -624,11 +624,11 @@ exports[`Snapshot test 1`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {
@@ -3347,11 +3347,11 @@ exports[`Snapshot test 1`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -671,11 +671,11 @@ exports[`Snapshot test 1`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {
@@ -3040,11 +3040,11 @@ exports[`Snapshot test 1`] = `
         "CapacityProviderStrategy": [
           {
             "CapacityProvider": "FARGATE",
-            "Weight": 0,
+            "Weight": 1,
           },
           {
             "CapacityProvider": "FARGATE_SPOT",
-            "Weight": 1,
+            "Weight": 0,
           },
         ],
         "Cluster": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Users can now explicitly opt-in to fargate spot capacity, which offeres trade-off of interruption risk vs cost.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
