### PR TITLE
(doc): fix automatic migration to true in the final step of migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ When you upgrade Dify from v0 to v1, you need to execute some migration steps de
    poetry run flask extract-plugins --workers=20
    poetry run flask install-plugins --workers=2
    ```
-6. After the commands run successfully, set `autoMigration: false`, and deploy CDK again. You should be now onboard with Dify v1.
+6. After the commands run successfully, set `autoMigration: true`, and deploy CDK again. You should be now onboard with Dify v1.
 
 ## Clean up
 To avoid incurring future charges, clean up the resources you created.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Once we've completed the migration steps, revise the documentation to use automatic migration again.

Currently, in the final step of migration, it is expected that automatic migration will be set from `false` to `true`, but the procedure remains `false`, and users will continue to need manual updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
