### PR TITLE
fix the latest plugin-daemon fails to start

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -349,6 +349,8 @@ export class ApiService extends Construct {
         DIFY_INNER_API_URL: `http://localhost:${port}`,
         PLUGIN_WORKING_PATH: '/app/storage/cwd',
         FORCE_VERIFYING_SIGNATURE: 'true',
+        S3_USE_AWS_MANAGED_IAM: 'true',
+        S3_ENDPOINT: `https://s3.${Stack.of(this).region}.amazonaws.com`,
       },
       secrets: {
         DB_USERNAME: ecs.Secret.fromSecretsManager(postgres.secret, 'username'),

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -2110,6 +2110,14 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Name": "FORCE_VERIFYING_SIGNATURE",
                 "Value": "true",
               },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
             ],
             "Essential": true,
             "Image": "langgenius/dify-plugin-daemon:main-local",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -1732,6 +1732,14 @@ exports[`Snapshot test 1`] = `
                 "Name": "FORCE_VERIFYING_SIGNATURE",
                 "Value": "true",
               },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
             ],
             "Essential": true,
             "Image": {

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -1752,6 +1752,14 @@ exports[`Snapshot test 1`] = `
                 "Name": "FORCE_VERIFYING_SIGNATURE",
                 "Value": "true",
               },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
             ],
             "Essential": true,
             "Image": "langgenius/dify-plugin-daemon:main-local",


### PR DESCRIPTION
*Issue #, if available:*
closes #48 

*Description of changes:*

https://github.com/langgenius/dify-plugin-daemon/pull/107 introduced a breaking change that caused the below error on startup:

>server.go:31: [PANIC]Failed to create s3 storage: operation error S3: CreateBucket, resolve auth scheme: resolve endpoint: endpoint rule error, Custom endpoint `` was not a valid URI

This PR explicitly sets S3_ENDPOINT environment variable to avoid the error. It seems we don't need to set S3_USE_AWS_MANAGED_IAM but just setting it to make sure it is enabled.

We'll consider pinning the plugin-daemon version instead of using `main-local` tag in another PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
