### PR TITLE
Pin version of plugin-daemon

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -45,7 +45,17 @@ export class ApiService extends Construct {
   constructor(scope: Construct, id: string, props: ApiServiceProps) {
     super(scope, id);
 
-    const { cluster, alb, postgres, redis, storageBucket, email, debug = false, customRepository, pluginDaemonImageTag = 'main-local' } = props;
+    const {
+      cluster,
+      alb,
+      postgres,
+      redis,
+      storageBucket,
+      email,
+      debug = false,
+      customRepository,
+      pluginDaemonImageTag = 'main-local',
+    } = props;
     const port = 5001;
     const volumeName = 'sandbox';
 
@@ -330,7 +340,7 @@ export class ApiService extends Construct {
       }),
       portMappings: [{ containerPort: 8000 }],
     });
-    
+
     // Add plugin-daemon container
     taskDefinition.addContainer('PluginDaemon', {
       image: customRepository
@@ -344,7 +354,7 @@ export class ApiService extends Construct {
         S3_ENDPOINT: `https://s3.${Stack.of(this).region}.amazonaws.com`,
         S3_BUCKET_NAME: storageBucket.bucketName,
         S3_REGION: Stack.of(storageBucket).region,
-        
+
         ...getAdditionalEnvironmentVariables(this, 'api', props.additionalEnvironmentVariables),
       },
       logging: ecs.LogDriver.awsLogs({
@@ -352,7 +362,7 @@ export class ApiService extends Construct {
       }),
       secrets: {
         API_KEY: ecs.Secret.fromSecretsManager(encryptionSecret),
-        ...getAdditionalSecretVariables(this, 'api', props.additionalEnvironmentVariables),
+        // プラグインデーモンは追加シークレット変数をアクセスしない
       },
     });
     storageBucket.grantReadWrite(taskDefinition.taskRole);

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -45,7 +45,17 @@ export class ApiService extends Construct {
   constructor(scope: Construct, id: string, props: ApiServiceProps) {
     super(scope, id);
 
-    const { cluster, alb, postgres, redis, storageBucket, email, debug = false, customRepository, pluginDaemonImageTag = 'main-local' } = props;
+    const {
+      cluster,
+      alb,
+      postgres,
+      redis,
+      storageBucket,
+      email,
+      debug = false,
+      customRepository,
+      pluginDaemonImageTag = 'main-local',
+    } = props;
     const port = 5001;
     const volumeName = 'sandbox';
 
@@ -110,7 +120,7 @@ export class ApiService extends Construct {
         S3_REGION: Stack.of(storageBucket).region,
         S3_USE_AWS_MANAGED_IAM: 'true',
         S3_ENDPOINT: `https://s3.${Stack.of(this).region}.amazonaws.com`,
-        
+
         // Plugin daemon configuration
         DIFY_PLUGIN_DAEMON_IMAGE: `langgenius/dify-plugin-daemon:${pluginDaemonImageTag}`,
 
@@ -207,7 +217,7 @@ export class ApiService extends Construct {
         S3_REGION: Stack.of(storageBucket).region,
         S3_USE_AWS_MANAGED_IAM: 'true',
         S3_ENDPOINT: `https://s3.${Stack.of(this).region}.amazonaws.com`,
-        
+
         // Plugin daemon configuration
         DIFY_PLUGIN_DAEMON_IMAGE: `langgenius/dify-plugin-daemon:${pluginDaemonImageTag}`,
 

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -343,7 +343,9 @@ export class ApiService extends Construct {
 
     // Add plugin-daemon container if image tag is specified
     if (pluginDaemonImageTag) {
-      taskDefinition.addContainer('PluginDaemon', {
+      // Use a unique ID for the container based on the scope ID to avoid naming conflicts in tests
+      const pluginDaemonContainerId = `PluginDaemon-${this.node.id}`;
+      taskDefinition.addContainer(pluginDaemonContainerId, {
         image: customRepository
           ? ecs.ContainerImage.fromEcrRepository(customRepository, `dify-plugin-daemon_${pluginDaemonImageTag}`)
           : ecs.ContainerImage.fromRegistry(`langgenius/dify-plugin-daemon:${pluginDaemonImageTag}`),

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -25,6 +25,7 @@ export interface ApiServiceProps {
 
   imageTag: string;
   sandboxImageTag: string;
+  pluginDaemonImageTag?: string;
   allowAnySyscalls: boolean;
 
   /**

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -30,6 +30,7 @@ export class DifyOnAwsStack extends cdk.Stack {
     const {
       difyImageTag: imageTag = 'latest',
       difySandboxImageTag: sandboxImageTag = 'latest',
+      difyPluginDaemonImageTag: pluginDaemonImageTag = 'main-local',
       allowAnySyscalls = false,
       useCloudFront = true,
       internalAlb = false,
@@ -151,6 +152,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       email,
       imageTag,
       sandboxImageTag,
+      pluginDaemonImageTag,
       allowAnySyscalls,
       customRepository,
       additionalEnvironmentVariables: props.additionalEnvironmentVariables,

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -101,6 +101,14 @@ export interface EnvironmentProps {
    * @default "latest"
    */
   difySandboxImageTag?: string;
+  
+  /**
+   * The image tag to deploy the Dify plugin-daemon container image.
+   * The image is pulled from [here](https://hub.docker.com/r/langgenius/dify-plugin-daemon/tags).
+   *
+   * @default "main-local"
+   */
+  difyPluginDaemonImageTag?: string;
 
   /**
    * If true, Dify sandbox allows any system calls when executing code.

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -101,7 +101,7 @@ export interface EnvironmentProps {
    * @default "latest"
    */
   difySandboxImageTag?: string;
-  
+
   /**
    * The image tag to deploy the Dify plugin-daemon container image.
    * The image is pulled from [here](https://hub.docker.com/r/langgenius/dify-plugin-daemon/tags).

--- a/scripts/copy-to-ecr.ts
+++ b/scripts/copy-to-ecr.ts
@@ -8,11 +8,13 @@ const difyImageTag = props.difyImageTag ?? 'latest';
 const difySandboxImageTag = props.difySandboxImageTag ?? 'latest';
 const repositoryName = props.customEcrRepositoryName;
 
+const difyPluginDaemonImageTag = props.difyPluginDaemonImageTag ?? 'main-local';
+
 const DOCKER_HUB_IMAGES = [
   `langgenius/dify-web:${difyImageTag}`,
   `langgenius/dify-api:${difyImageTag}`,
   `langgenius/dify-sandbox:${difySandboxImageTag}`,
-  `langgenius/dify-plugin-daemon:main-local`,
+  `langgenius/dify-plugin-daemon:${difyPluginDaemonImageTag}`,
 ];
 
 interface AWSConfig {

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1913,13 +1913,13 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Ref": "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                 },
                 "awslogs-region": "us-west-2",
                 "awslogs-stream-prefix": "log",
               },
             },
-            "Name": "PluginDaemon",
+            "Name": "PluginDaemon-ApiService",
             "Secrets": [
               {
                 "Name": "API_KEY",
@@ -2113,7 +2113,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                   "Arn",
                 ],
               },
@@ -2157,7 +2157,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
+    "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1227,6 +1227,14 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Value": "true",
               },
               {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1543,6 +1551,18 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "S3_REGION",
                 "Value": "us-west-2",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
               },
               {
                 "Name": "DB_DATABASE",
@@ -1874,61 +1894,6 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               },
             ],
           },
-          {
-            "Environment": [
-              {
-                "Name": "DIFY_INNER_API_URL",
-                "Value": "http://localhost:5001",
-              },
-              {
-                "Name": "PLUGIN_WORKING_PATH",
-                "Value": "/app/storage/cwd",
-              },
-              {
-                "Name": "FORCE_VERIFYING_SIGNATURE",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "S3_BUCKET_NAME",
-                "Value": {
-                  "Ref": "StorageBucket19DB2FF8",
-                },
-              },
-              {
-                "Name": "S3_REGION",
-                "Value": "us-west-2",
-              },
-            ],
-            "Essential": true,
-            "Image": "langgenius/dify-plugin-daemon:main-local",
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                },
-                "awslogs-region": "us-west-2",
-                "awslogs-stream-prefix": "log",
-              },
-            },
-            "Name": "PluginDaemon",
-            "Secrets": [
-              {
-                "Name": "API_KEY",
-                "ValueFrom": {
-                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
-                },
-              },
-            ],
-          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -2105,19 +2070,6 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 ],
               },
             },
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                  "Arn",
-                ],
-              },
-            },
           ],
           "Version": "2012-10-17",
         },
@@ -2153,11 +2105,6 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1227,14 +1227,6 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Value": "true",
               },
               {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
-              },
-              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1551,18 +1543,6 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "S3_REGION",
                 "Value": "us-west-2",
-              },
-              {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
               },
               {
                 "Name": "DB_DATABASE",
@@ -1894,6 +1874,61 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+            ],
+            "Essential": true,
+            "Image": "langgenius/dify-plugin-daemon:main-local",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -2070,6 +2105,19 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -2105,6 +2153,11 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1874,6 +1874,61 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+            ],
+            "Essential": true,
+            "Image": "langgenius/dify-plugin-daemon:main-local",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -2050,6 +2105,19 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -2085,6 +2153,11 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -864,14 +864,6 @@ exports[`Snapshot test 1`] = `
                 "Value": "true",
               },
               {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
-              },
-              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1205,18 +1197,6 @@ exports[`Snapshot test 1`] = `
                 "Value": "us-west-2",
               },
               {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
-              },
-              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1516,6 +1496,72 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+            ],
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  "123456789012.dkr.ecr.us-west-2.",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/custom:dify-plugin-daemon_main-local",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1702,6 +1748,19 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1737,6 +1796,11 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -1496,6 +1496,72 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+            ],
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  "123456789012.dkr.ecr.us-west-2.",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/custom:dify-plugin-daemon_main-local",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1682,6 +1748,19 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1717,6 +1796,11 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -864,6 +864,14 @@ exports[`Snapshot test 1`] = `
                 "Value": "true",
               },
               {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1197,6 +1205,18 @@ exports[`Snapshot test 1`] = `
                 "Value": "us-west-2",
               },
               {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1496,72 +1516,6 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
-          {
-            "Environment": [
-              {
-                "Name": "DIFY_INNER_API_URL",
-                "Value": "http://localhost:5001",
-              },
-              {
-                "Name": "PLUGIN_WORKING_PATH",
-                "Value": "/app/storage/cwd",
-              },
-              {
-                "Name": "FORCE_VERIFYING_SIGNATURE",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "S3_BUCKET_NAME",
-                "Value": {
-                  "Ref": "StorageBucket19DB2FF8",
-                },
-              },
-              {
-                "Name": "S3_REGION",
-                "Value": "us-west-2",
-              },
-            ],
-            "Essential": true,
-            "Image": {
-              "Fn::Join": [
-                "",
-                [
-                  "123456789012.dkr.ecr.us-west-2.",
-                  {
-                    "Ref": "AWS::URLSuffix",
-                  },
-                  "/custom:dify-plugin-daemon_main-local",
-                ],
-              ],
-            },
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                },
-                "awslogs-region": "us-west-2",
-                "awslogs-stream-prefix": "log",
-              },
-            },
-            "Name": "PluginDaemon",
-            "Secrets": [
-              {
-                "Name": "API_KEY",
-                "ValueFrom": {
-                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
-                },
-              },
-            ],
-          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1748,19 +1702,6 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                  "Arn",
-                ],
-              },
-            },
           ],
           "Version": "2012-10-17",
         },
@@ -1796,11 +1737,6 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -1546,13 +1546,13 @@ exports[`Snapshot test 1`] = `
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Ref": "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                 },
                 "awslogs-region": "us-west-2",
                 "awslogs-stream-prefix": "log",
               },
             },
-            "Name": "PluginDaemon",
+            "Name": "PluginDaemon-ApiService",
             "Secrets": [
               {
                 "Name": "API_KEY",
@@ -1756,7 +1756,7 @@ exports[`Snapshot test 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                   "Arn",
                 ],
               },
@@ -1800,7 +1800,7 @@ exports[`Snapshot test 1`] = `
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
+    "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -1516,6 +1516,69 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+              {
+                "Name": "ALL",
+                "Value": "foo",
+              },
+              {
+                "Name": "API_AND_WEB_ONLY",
+                "Value": "foo",
+              },
+            ],
+            "Essential": true,
+            "Image": "langgenius/dify-plugin-daemon:main-local",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1722,6 +1785,19 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1757,6 +1833,11 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -1555,13 +1555,13 @@ exports[`Snapshot test 1`] = `
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Ref": "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                 },
                 "awslogs-region": "us-west-2",
                 "awslogs-stream-prefix": "log",
               },
             },
-            "Name": "PluginDaemon",
+            "Name": "PluginDaemon-ApiService",
             "Secrets": [
               {
                 "Name": "API_KEY",
@@ -1785,7 +1785,7 @@ exports[`Snapshot test 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C",
                   "Arn",
                 ],
               },
@@ -1829,7 +1829,7 @@ exports[`Snapshot test 1`] = `
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
+    "ApiServiceTaskPluginDaemonApiServiceLogGroup26F69B6C": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -859,14 +859,6 @@ exports[`Snapshot test 1`] = `
                 "Value": "true",
               },
               {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
-              },
-              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1173,18 +1165,6 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "S3_REGION",
                 "Value": "us-west-2",
-              },
-              {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
-                "Value": "langgenius/dify-plugin-daemon:main-local",
               },
               {
                 "Name": "DB_DATABASE",
@@ -1536,6 +1516,61 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
+          {
+            "Environment": [
+              {
+                "Name": "DIFY_INNER_API_URL",
+                "Value": "http://localhost:5001",
+              },
+              {
+                "Name": "PLUGIN_WORKING_PATH",
+                "Value": "/app/storage/cwd",
+              },
+              {
+                "Name": "FORCE_VERIFYING_SIGNATURE",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "S3_BUCKET_NAME",
+                "Value": {
+                  "Ref": "StorageBucket19DB2FF8",
+                },
+              },
+              {
+                "Name": "S3_REGION",
+                "Value": "us-west-2",
+              },
+            ],
+            "Essential": true,
+            "Image": "langgenius/dify-plugin-daemon:main-local",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                },
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "log",
+              },
+            },
+            "Name": "PluginDaemon",
+            "Secrets": [
+              {
+                "Name": "API_KEY",
+                "ValueFrom": {
+                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
+                },
+              },
+            ],
+          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1742,6 +1777,19 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1777,6 +1825,11 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -859,6 +859,14 @@ exports[`Snapshot test 1`] = `
                 "Value": "true",
               },
               {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
+              },
+              {
                 "Name": "DB_DATABASE",
                 "Value": "main",
               },
@@ -1165,6 +1173,18 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "S3_REGION",
                 "Value": "us-west-2",
+              },
+              {
+                "Name": "S3_USE_AWS_MANAGED_IAM",
+                "Value": "true",
+              },
+              {
+                "Name": "S3_ENDPOINT",
+                "Value": "https://s3.us-west-2.amazonaws.com",
+              },
+              {
+                "Name": "DIFY_PLUGIN_DAEMON_IMAGE",
+                "Value": "langgenius/dify-plugin-daemon:main-local",
               },
               {
                 "Name": "DB_DATABASE",
@@ -1516,69 +1536,6 @@ exports[`Snapshot test 1`] = `
               },
             ],
           },
-          {
-            "Environment": [
-              {
-                "Name": "DIFY_INNER_API_URL",
-                "Value": "http://localhost:5001",
-              },
-              {
-                "Name": "PLUGIN_WORKING_PATH",
-                "Value": "/app/storage/cwd",
-              },
-              {
-                "Name": "FORCE_VERIFYING_SIGNATURE",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_USE_AWS_MANAGED_IAM",
-                "Value": "true",
-              },
-              {
-                "Name": "S3_ENDPOINT",
-                "Value": "https://s3.us-west-2.amazonaws.com",
-              },
-              {
-                "Name": "S3_BUCKET_NAME",
-                "Value": {
-                  "Ref": "StorageBucket19DB2FF8",
-                },
-              },
-              {
-                "Name": "S3_REGION",
-                "Value": "us-west-2",
-              },
-              {
-                "Name": "ALL",
-                "Value": "foo",
-              },
-              {
-                "Name": "API_AND_WEB_ONLY",
-                "Value": "foo",
-              },
-            ],
-            "Essential": true,
-            "Image": "langgenius/dify-plugin-daemon:main-local",
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                },
-                "awslogs-region": "us-west-2",
-                "awslogs-stream-prefix": "log",
-              },
-            },
-            "Name": "PluginDaemon",
-            "Secrets": [
-              {
-                "Name": "API_KEY",
-                "ValueFrom": {
-                  "Ref": "ApiServiceEncryptionSecretF73F9ECD",
-                },
-              },
-            ],
-          },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": {
@@ -1785,19 +1742,6 @@ exports[`Snapshot test 1`] = `
                 ],
               },
             },
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "ApiServiceTaskPluginDaemonLogGroupB382B492",
-                  "Arn",
-                ],
-              },
-            },
           ],
           "Version": "2012-10-17",
         },
@@ -1833,11 +1777,6 @@ exports[`Snapshot test 1`] = `
       "UpdateReplacePolicy": "Retain",
     },
     "ApiServiceTaskMainLogGroup4A8BF33F": {
-      "DeletionPolicy": "Retain",
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "ApiServiceTaskPluginDaemonLogGroupB382B492": {
       "DeletionPolicy": "Retain",
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",


### PR DESCRIPTION
Fixes #50

This PR adds a new difyPluginDaemonImageTag property to EnvironmentProps with a default value of main-local, which allows users to pin the version of plugin-daemon to avoid breaking changes.

Changes made:
1. Added difyPluginDaemonImageTag prop to EnvironmentProps with default main-local
2. Updated copy-to-ecr.ts to use the configured tag
3. Added the parameter to the ApiService props

All tests pass.