### PR TITLE
Pin version of plugin-daemon

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -10,6 +10,8 @@ export const props: EnvironmentProps = {
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
   difyImageTag: '1.0.0',
+  // Set plugin-daemon version to stable release
+  difyPluginDaemonImageTag: '0.0.6-local',
 
   // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -26,7 +26,7 @@ export interface ApiServiceProps {
 
   imageTag: string;
   sandboxImageTag: string;
-  pluginDaemonImageTag?: string;
+  pluginDaemonImageTag: string;
   allowAnySyscalls: boolean;
 
   /**
@@ -311,11 +311,10 @@ export class ApiService extends Construct {
       condition: ecs.ContainerDependencyCondition.COMPLETE,
     });
 
-    const pluginDaemonImageTag = props.pluginDaemonImageTag || 'main-local';
     taskDefinition.addContainer('PluginDaemon', {
       image: customRepository
-        ? ecs.ContainerImage.fromEcrRepository(customRepository, `dify-plugin-daemon_${pluginDaemonImageTag}`)
-        : ecs.ContainerImage.fromRegistry(`langgenius/dify-plugin-daemon:${pluginDaemonImageTag}`),
+        ? ecs.ContainerImage.fromEcrRepository(customRepository, `dify-plugin-daemon_${props.pluginDaemonImageTag}`)
+        : ecs.ContainerImage.fromRegistry(`langgenius/dify-plugin-daemon:${props.pluginDaemonImageTag}`),
       environment: {
         GIN_MODE: 'release',
 

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -26,6 +26,7 @@ export interface ApiServiceProps {
 
   imageTag: string;
   sandboxImageTag: string;
+  pluginDaemonImageTag?: string;
   allowAnySyscalls: boolean;
 
   /**
@@ -310,10 +311,11 @@ export class ApiService extends Construct {
       condition: ecs.ContainerDependencyCondition.COMPLETE,
     });
 
+    const pluginDaemonImageTag = props.pluginDaemonImageTag || 'main-local';
     taskDefinition.addContainer('PluginDaemon', {
       image: customRepository
-        ? ecs.ContainerImage.fromEcrRepository(customRepository, `dify-plugin-daemon_main-local`)
-        : ecs.ContainerImage.fromRegistry(`langgenius/dify-plugin-daemon:main-local`),
+        ? ecs.ContainerImage.fromEcrRepository(customRepository, `dify-plugin-daemon_${pluginDaemonImageTag}`)
+        : ecs.ContainerImage.fromRegistry(`langgenius/dify-plugin-daemon:${pluginDaemonImageTag}`),
       environment: {
         GIN_MODE: 'release',
 

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -30,6 +30,7 @@ export class DifyOnAwsStack extends cdk.Stack {
     const {
       difyImageTag: imageTag = 'latest',
       difySandboxImageTag: sandboxImageTag = 'latest',
+      difyPluginDaemonImageTag: pluginDaemonImageTag = 'main-local',
       allowAnySyscalls = false,
       useCloudFront = true,
       internalAlb = false,
@@ -151,6 +152,7 @@ export class DifyOnAwsStack extends cdk.Stack {
       email,
       imageTag,
       sandboxImageTag,
+      pluginDaemonImageTag,
       allowAnySyscalls,
       customRepository,
       additionalEnvironmentVariables: props.additionalEnvironmentVariables,

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -103,6 +103,14 @@ export interface EnvironmentProps {
   difySandboxImageTag?: string;
 
   /**
+   * The image tag to deploy the Dify plugin-daemon container image.
+   * The image is pulled from [here](https://hub.docker.com/r/langgenius/dify-plugin-daemon/tags).
+   *
+   * @default "main-local"
+   */
+  difyPluginDaemonImageTag?: string;
+
+  /**
    * If true, Dify sandbox allows any system calls when executing code.
    * Do NOT set this property if you are not sure code executed in the sandbox
    * can be trusted or not.

--- a/scripts/copy-to-ecr.ts
+++ b/scripts/copy-to-ecr.ts
@@ -6,13 +6,14 @@ const execAsync = promisify(exec);
 
 const difyImageTag = props.difyImageTag ?? 'latest';
 const difySandboxImageTag = props.difySandboxImageTag ?? 'latest';
+const difyPluginDaemonImageTag = props.difyPluginDaemonImageTag ?? 'main-local';
 const repositoryName = props.customEcrRepositoryName;
 
 const DOCKER_HUB_IMAGES = [
   `langgenius/dify-web:${difyImageTag}`,
   `langgenius/dify-api:${difyImageTag}`,
   `langgenius/dify-sandbox:${difySandboxImageTag}`,
-  `langgenius/dify-plugin-daemon:main-local`,
+  `langgenius/dify-plugin-daemon:${difyPluginDaemonImageTag}`,
 ];
 
 interface AWSConfig {


### PR DESCRIPTION
Fixes #50

## 変更内容
- Added `difyPluginDaemonImageTag` prop to `EnvironmentProps` with default value `main-local`
- Passing this prop from stack to the plugin-daemon container definition in api.ts
- Updated copy-to-ecr.ts to use `difyPluginDaemonImageTag` prop
- Set the default value to stable version `0.0.6-local` in bin/cdk.ts

This allows users to specify and pin a specific version of the plugin-daemon to prevent breaking changes.