### PR TITLE
feat: increase timeouts for ALB and text generation

### DIFF
--- a/lib/constructs/alb.ts
+++ b/lib/constructs/alb.ts
@@ -73,6 +73,7 @@ export class Alb extends Construct implements IAlb {
         subnets: internal ? vpc.privateSubnets.concat(vpc.isolatedSubnets) : vpc.publicSubnets,
       }),
       internetFacing: !internal,
+      idleTimeout: Duration.seconds(600),
     });
     alb.logAccessLogs(accessLogBucket, 'dify-alb');
     this.url = `${protocol.toLowerCase()}://${alb.loadBalancerDnsName}`;

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -125,6 +125,8 @@ export class ApiService extends Construct {
 
         MARKETPLACE_API_URL: 'https://marketplace.dify.ai',
         MARKETPLACE_URL: 'https://marketplace.dify.ai',
+        
+        TEXT_GENERATION_TIMEOUT_MS: '600000',
 
         ...(email
           ? {
@@ -341,6 +343,8 @@ export class ApiService extends Construct {
         PLUGIN_REMOTE_INSTALLING_HOST: 'localhost',
         PLUGIN_REMOTE_INSTALLING_PORT: '5003',
 
+        TEXT_GENERATION_TIMEOUT_MS: '600000',
+        
         ROUTINE_POOL_SIZE: '10000',
         LIFETIME_COLLECTION_HEARTBEAT_INTERVAL: '5',
         LIFETIME_COLLECTION_GC_INTERVAL: '60',

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -125,7 +125,7 @@ export class ApiService extends Construct {
 
         MARKETPLACE_API_URL: 'https://marketplace.dify.ai',
         MARKETPLACE_URL: 'https://marketplace.dify.ai',
-        
+
         TEXT_GENERATION_TIMEOUT_MS: '600000',
 
         ...(email
@@ -344,7 +344,7 @@ export class ApiService extends Construct {
         PLUGIN_REMOTE_INSTALLING_PORT: '5003',
 
         TEXT_GENERATION_TIMEOUT_MS: '600000',
-        
+
         ROUTINE_POOL_SIZE: '10000',
         LIFETIME_COLLECTION_HEARTBEAT_INTERVAL: '5',
         LIFETIME_COLLECTION_GC_INTERVAL: '60',

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -1373,6 +1373,10 @@ exports[`Snapshot test (with CloudFront) 2`] = `
                 "Value": "https://marketplace.dify.ai",
               },
               {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
+              },
+              {
                 "Name": "MAIL_TYPE",
                 "Value": "smtp",
               },
@@ -2073,6 +2077,10 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "PLUGIN_REMOTE_INSTALLING_PORT",
                 "Value": "5003",
+              },
+              {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
               },
               {
                 "Name": "ROUTINE_POOL_SIZE",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -403,6 +403,10 @@ exports[`Snapshot test 1`] = `
             "Value": "false",
           },
           {
+            "Key": "idle_timeout.timeout_seconds",
+            "Value": "600",
+          },
+          {
             "Key": "access_logs.s3.enabled",
             "Value": "true",
           },
@@ -1008,6 +1012,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "MARKETPLACE_URL",
                 "Value": "https://marketplace.dify.ai",
+              },
+              {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
               },
             ],
             "Essential": true,
@@ -1695,6 +1703,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "PLUGIN_REMOTE_INSTALLING_PORT",
                 "Value": "5003",
+              },
+              {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
               },
               {
                 "Name": "ROUTINE_POOL_SIZE",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -424,6 +424,10 @@ exports[`Snapshot test 1`] = `
             "Value": "false",
           },
           {
+            "Key": "idle_timeout.timeout_seconds",
+            "Value": "600",
+          },
+          {
             "Key": "access_logs.s3.enabled",
             "Value": "true",
           },
@@ -1003,6 +1007,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "MARKETPLACE_URL",
                 "Value": "https://marketplace.dify.ai",
+              },
+              {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
               },
               {
                 "Name": "ALL",
@@ -1715,6 +1723,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "PLUGIN_REMOTE_INSTALLING_PORT",
                 "Value": "5003",
+              },
+              {
+                "Name": "TEXT_GENERATION_TIMEOUT_MS",
+                "Value": "600000",
               },
               {
                 "Name": "ROUTINE_POOL_SIZE",


### PR DESCRIPTION
## Changes

1. Increased ALB idle timeout from default 60s to 600s
   - Added idleTimeout: Duration.seconds(600) to ALB configuration

2. Added TEXT_GENERATION_TIMEOUT_MS environment variable to Dify containers
   - Set TEXT_GENERATION_TIMEOUT_MS: '600000' in both API and plugin-daemon containers

These changes prevent timeouts when processing long-running LLM requests.