### PR TITLE
support Dify extension api endpoints

### DIFF
--- a/lib/constructs/alb-with-cloudfront.ts
+++ b/lib/constructs/alb-with-cloudfront.ts
@@ -139,7 +139,13 @@ export class AlbWithCloudFront extends Construct implements IAlb {
     this.listener = listener;
   }
 
-  public addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]) {
+  public addEcsService(
+    id: string,
+    ecsService: IEcsLoadBalancerTarget,
+    port: number,
+    healthCheckPath: string,
+    paths: string[],
+  ) {
     // we need different target group ids for different albs because a single target group can be attached to only one alb.
     const group = new ApplicationTargetGroup(this, `${id}TargetGroupInternal`, {
       vpc: this.vpc,

--- a/lib/constructs/alb-with-cloudfront.ts
+++ b/lib/constructs/alb-with-cloudfront.ts
@@ -10,7 +10,7 @@ import {
 } from 'aws-cdk-lib/aws-cloudfront';
 import { LoadBalancerV2Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { IVpc, Peer } from 'aws-cdk-lib/aws-ec2';
-import { FargateService } from 'aws-cdk-lib/aws-ecs';
+import { IEcsLoadBalancerTarget } from 'aws-cdk-lib/aws-ecs';
 import {
   ApplicationListener,
   ApplicationLoadBalancer,
@@ -62,6 +62,7 @@ export class AlbWithCloudFront extends Construct implements IAlb {
       vpc,
       vpcSubnets: vpc.selectSubnets({ subnets: vpc.privateSubnets }),
       internetFacing: false,
+      idleTimeout: Duration.seconds(600),
     });
     alb.logAccessLogs(accessLogBucket, 'dify-alb');
     this.url = `${protocol.toLowerCase()}://${alb.loadBalancerDnsName}`;
@@ -138,13 +139,13 @@ export class AlbWithCloudFront extends Construct implements IAlb {
     this.listener = listener;
   }
 
-  public addEcsService(id: string, ecsService: FargateService, port: number, healthCheckPath: string, paths: string[]) {
+  public addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]) {
     // we need different target group ids for different albs because a single target group can be attached to only one alb.
     const group = new ApplicationTargetGroup(this, `${id}TargetGroupInternal`, {
       vpc: this.vpc,
       targets: [ecsService],
       protocol: ApplicationProtocol.HTTP,
-      port: port,
+      port,
       deregistrationDelay: Duration.seconds(10),
       healthCheck: {
         path: healthCheckPath,

--- a/lib/constructs/alb.ts
+++ b/lib/constructs/alb.ts
@@ -38,7 +38,13 @@ export interface AlbProps {
 
 export interface IAlb {
   url: string;
-  addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]): void;
+  addEcsService(
+    id: string,
+    ecsService: IEcsLoadBalancerTarget,
+    port: number,
+    healthCheckPath: string,
+    paths: string[],
+  ): void;
 }
 
 export class Alb extends Construct implements IAlb {
@@ -100,7 +106,13 @@ export class Alb extends Construct implements IAlb {
     this.listener = listener;
   }
 
-  public addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]) {
+  public addEcsService(
+    id: string,
+    ecsService: IEcsLoadBalancerTarget,
+    port: number,
+    healthCheckPath: string,
+    paths: string[],
+  ) {
     const group = new ApplicationTargetGroup(this, `${id}TargetGroup`, {
       vpc: this.vpc,
       targets: [ecsService],

--- a/lib/constructs/alb.ts
+++ b/lib/constructs/alb.ts
@@ -1,7 +1,7 @@
 import { Duration } from 'aws-cdk-lib';
 import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
 import { IVpc, Peer } from 'aws-cdk-lib/aws-ec2';
-import { FargateService } from 'aws-cdk-lib/aws-ecs';
+import { IEcsLoadBalancerTarget } from 'aws-cdk-lib/aws-ecs';
 import {
   ApplicationListener,
   ApplicationLoadBalancer,
@@ -38,7 +38,7 @@ export interface AlbProps {
 
 export interface IAlb {
   url: string;
-  addEcsService(id: string, ecsService: FargateService, port: number, healthCheckPath: string, paths: string[]): void;
+  addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]): void;
 }
 
 export class Alb extends Construct implements IAlb {
@@ -100,12 +100,12 @@ export class Alb extends Construct implements IAlb {
     this.listener = listener;
   }
 
-  public addEcsService(id: string, ecsService: FargateService, port: number, healthCheckPath: string, paths: string[]) {
+  public addEcsService(id: string, ecsService: IEcsLoadBalancerTarget, port: number, healthCheckPath: string, paths: string[]) {
     const group = new ApplicationTargetGroup(this, `${id}TargetGroup`, {
       vpc: this.vpc,
       targets: [ecsService],
       protocol: ApplicationProtocol.HTTP,
-      port: port,
+      port,
       deregistrationDelay: Duration.seconds(10),
       healthCheck: {
         path: healthCheckPath,

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -672,6 +672,10 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             "Value": "false",
           },
           {
+            "Key": "idle_timeout.timeout_seconds",
+            "Value": "600",
+          },
+          {
             "Key": "access_logs.s3.enabled",
             "Value": "true",
           },
@@ -780,6 +784,34 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         },
       },
       "Type": "AWS::CloudFront::Distribution",
+    },
+    "AlbExtensionTargetGroupInternal7D926089": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckPath": "/health/check",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5002,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 6,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "AlbGetCloudFrontPrefixListId0ED122F4": {
       "DeletionPolicy": "Delete",
@@ -899,6 +931,34 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
+    "AlbListenerExtension0Rule76BF40E2": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroupInternal7D926089",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/e",
+                "/e/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
+        "Priority": 3,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "AlbListenerWeb0RuleE10BEE0F": {
       "Properties": {
         "Actions": [
@@ -922,7 +982,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 3,
+        "Priority": 4,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
@@ -988,6 +1048,27 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         },
         "IpProtocol": "tcp",
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "AlbSecurityGrouptoTestStackApiServiceFargateServiceSecurityGroup7DD0AF4450024F600494": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -1150,6 +1231,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
       "DependsOn": [
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
+        "AlbListenerExtension0Rule76BF40E2",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -1185,6 +1267,13 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroupInternal2EB9930E",
+            },
+          },
+          {
+            "ContainerName": "PluginDaemon",
+            "ContainerPort": 5002,
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroupInternal7D926089",
             },
           },
         ],
@@ -1257,6 +1346,31 @@ exports[`Snapshot test (with CloudFront) 2`] = `
           ],
         },
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "ApiServiceFargateServiceSecurityGroupfromTestStackAlbSecurityGroup8A47F1DC5002033681A8": {
+      "DependsOn": [
+        "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
+        "ApiServiceTaskTaskRole06F87EBE",
+      ],
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -1375,6 +1489,10 @@ exports[`Snapshot test (with CloudFront) 2`] = `
               {
                 "Name": "TEXT_GENERATION_TIMEOUT_MS",
                 "Value": "600000",
+              },
+              {
+                "Name": "ENDPOINT_URL_TEMPLATE",
+                "Value": "https://dify.example.com/e/{hook_id}",
               },
               {
                 "Name": "MAIL_TYPE",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -442,6 +442,34 @@ exports[`Snapshot test 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
     },
+    "AlbExtensionTargetGroup73E67323": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/health/check",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5002,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 10,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
     "AlbListener318AEEBA": {
       "Properties": {
         "DefaultActions": [
@@ -520,6 +548,34 @@ exports[`Snapshot test 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
+    "AlbListenerExtension0Rule76BF40E2": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroup73E67323",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/e",
+                "/e/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
+        "Priority": 3,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "AlbListenerWeb0RuleE10BEE0F": {
       "Properties": {
         "Actions": [
@@ -543,7 +599,7 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 3,
+        "Priority": 4,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
@@ -590,6 +646,27 @@ exports[`Snapshot test 1`] = `
         },
         "IpProtocol": "tcp",
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "AlbSecurityGrouptoTestStackApiServiceFargateServiceSecurityGroup7DD0AF4450024F600494": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -739,6 +816,7 @@ exports[`Snapshot test 1`] = `
       "DependsOn": [
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
+        "AlbListenerExtension0Rule76BF40E2",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -774,6 +852,13 @@ exports[`Snapshot test 1`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroup4B6AF19C",
+            },
+          },
+          {
+            "ContainerName": "PluginDaemon",
+            "ContainerPort": 5002,
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroup73E67323",
             },
           },
         ],
@@ -846,6 +931,31 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "ApiServiceFargateServiceSecurityGroupfromTestStackAlbSecurityGroup8A47F1DC5002033681A8": {
+      "DependsOn": [
+        "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
+        "ApiServiceTaskTaskRole06F87EBE",
+      ],
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -1016,6 +1126,24 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "TEXT_GENERATION_TIMEOUT_MS",
                 "Value": "600000",
+              },
+              {
+                "Name": "ENDPOINT_URL_TEMPLATE",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "http://",
+                      {
+                        "Fn::GetAtt": [
+                          "AlbC1372A32",
+                          "DNSName",
+                        ],
+                      },
+                      "/e/{hook_id}",
+                    ],
+                  ],
+                },
               },
             ],
             "Essential": true,

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -482,6 +482,34 @@ exports[`Snapshot test 1`] = `
       },
       "Type": "AWS::CertificateManager::Certificate",
     },
+    "AlbExtensionTargetGroup73E67323": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/health/check",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5002,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 10,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
     "AlbListener318AEEBA": {
       "Properties": {
         "Certificates": [
@@ -567,6 +595,34 @@ exports[`Snapshot test 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
+    "AlbListenerExtension0Rule76BF40E2": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroup73E67323",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/e",
+                "/e/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
+        "Priority": 3,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "AlbListenerWeb0RuleE10BEE0F": {
       "Properties": {
         "Actions": [
@@ -590,7 +646,7 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 3,
+        "Priority": 4,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
@@ -637,6 +693,27 @@ exports[`Snapshot test 1`] = `
         },
         "IpProtocol": "tcp",
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "AlbSecurityGrouptoTestStackApiServiceFargateServiceSecurityGroup7DD0AF4450024F600494": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -786,6 +863,7 @@ exports[`Snapshot test 1`] = `
       "DependsOn": [
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
+        "AlbListenerExtension0Rule76BF40E2",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -821,6 +899,13 @@ exports[`Snapshot test 1`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroup4B6AF19C",
+            },
+          },
+          {
+            "ContainerName": "PluginDaemon",
+            "ContainerPort": 5002,
+            "TargetGroupArn": {
+              "Ref": "AlbExtensionTargetGroup73E67323",
             },
           },
         ],
@@ -893,6 +978,31 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "ToPort": 5001,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "ApiServiceFargateServiceSecurityGroupfromTestStackAlbSecurityGroup8A47F1DC5002033681A8": {
+      "DependsOn": [
+        "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
+        "ApiServiceTaskTaskRole06F87EBE",
+      ],
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 5002,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "ApiServiceFargateServiceSecurityGroupE31C96C6",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "AlbSecurityGroup433229ED",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5002,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -1011,6 +1121,10 @@ exports[`Snapshot test 1`] = `
               {
                 "Name": "TEXT_GENERATION_TIMEOUT_MS",
                 "Value": "600000",
+              },
+              {
+                "Name": "ENDPOINT_URL_TEMPLATE",
+                "Value": "https://dify.example.com/e/{hook_id}",
               },
               {
                 "Name": "ALL",


### PR DESCRIPTION
*Issue #, if available:*

closes #71 

*Description of changes:*

The extension endpoints are directly served from the plugin daemon, so we expose the port 5002 from the ALB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
