### PR TITLE
upgrade Dify to 1.7.1

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -9,9 +9,9 @@ export const props: EnvironmentProps = {
   awsRegion: 'us-west-2',
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
-  difyImageTag: '1.4.3',
+  difyImageTag: '1.7.1',
   // Set plugin-daemon version to stable release
-  difyPluginDaemonImageTag: '0.1.2-local',
+  difyPluginDaemonImageTag: '0.2.0-local',
 
   // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,

--- a/lib/constructs/redis.ts
+++ b/lib/constructs/redis.ts
@@ -59,7 +59,8 @@ export class Redis extends Construct implements ec2.IConnectable {
     this.endpoint = redis.attrPrimaryEndPointAddress;
 
     this.brokerUrl = new StringParameter(this, 'BrokerUrl', {
-      stringValue: `rediss://:${secret.secretValue.unsafeUnwrap()}@${this.endpoint}:${this.port}/1`,
+      // Celery crashes when ssl_cert_reqs is not set
+      stringValue: `rediss://:${secret.secretValue.unsafeUnwrap()}@${this.endpoint}:${this.port}/1?ssl_cert_reqs=optional`,
     });
 
     this.connections = new ec2.Connections({ securityGroups: [securityGroup], defaultPort: ec2.Port.tcp(this.port) });


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Upgrade Dify to 1.7.1.

For some reason, Celery stopped working after update due to the below error: 

> 2025-08-08 01:24:13,366.366 CRITICAL [MainThread] [worker.py:207] - Unrecoverable error: ValueError('\nA rediss:// URL must have parameter ssl_cert_reqs and this must be set to CERT_REQUIRED, CERT_OPTIONAL, or CERT_NONE\n')

I found that Celery result backend is switched from Postgres to Redis:

```
In 1.4.3:
---------- .> transport: rediss://:**@master.redacted.apne1.cache.amazonaws.com:6379/1
---------- .> results: postgresql://postgres:**@difyonawsstack-redacted.cluster-cdxwnm5dehdj.ap-northeast-1.rds.amazonaws.com:5432/main

In 1.7.1
---------- .> transport: rediss://:**@master.redacted.apne1.cache.amazonaws.com:6379/1
---------- .> results: rediss://:**@master.redacted.apne1.cache.amazonaws.com:6379/1
```

But could not found any relevant upstream changes:

https://github.com/langgenius/dify/blob/084dcd1a504796043308f5fa4077f26d9e61e948/api/extensions/ext_celery.py#L44-L46
https://github.com/langgenius/dify/blob/084dcd1a504796043308f5fa4077f26d9e61e948/api/configs/middleware/__init__.py#L250-L257

At least, adding ssl_cert_reqs parameter resolved the issue and it seems it is working without problem. We'll monitor if this breaks anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
