### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 on: 
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/dify-self-hosted-on-aws/security/code-scanning/2](https://github.com/aws-samples/dify-self-hosted-on-aws/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` key and before `on:`), so it applies to all jobs. No changes to the jobs or steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
