### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_snaphost.yml
+++ b/.github/workflows/update_snaphost.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/dify-self-hosted-on-aws/security/code-scanning/1](https://github.com/aws-samples/dify-self-hosted-on-aws/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow or to the specific job that requires it. Since only the `update` job is present, and it performs a commit to the repository, it needs `contents: write` permission. The best way to fix this is to add a `permissions` block under the `update` job, specifying only the permissions required (`contents: write`). This change should be made in `.github/workflows/update_snaphost.yml`, immediately under the `runs-on: ubuntu-latest` line (line 11), before the `steps` block. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
