### PR TITLE
fix: add bedrock:GetInferenceProfile Policy to API service role (#89)

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -401,6 +401,7 @@ export class ApiService extends Construct {
     taskDefinition.taskRole.addToPrincipalPolicy(
       new PolicyStatement({
         actions: [
+          'bedrock:GetInferenceProfile',
           'bedrock:InvokeModel',
           'bedrock:InvokeModelWithResponseStream',
           'bedrock:ListFoundationModels',

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -2740,6 +2740,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             },
             {
               "Action": [
+                "bedrock:GetInferenceProfile",
                 "bedrock:InvokeModel",
                 "bedrock:InvokeModelWithResponseStream",
                 "bedrock:ListFoundationModels",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -2397,6 +2397,7 @@ exports[`Snapshot test 1`] = `
             },
             {
               "Action": [
+                "bedrock:GetInferenceProfile",
                 "bedrock:InvokeModel",
                 "bedrock:InvokeModelWithResponseStream",
                 "bedrock:ListFoundationModels",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -2412,6 +2412,7 @@ exports[`Snapshot test 1`] = `
             },
             {
               "Action": [
+                "bedrock:GetInferenceProfile",
                 "bedrock:InvokeModel",
                 "bedrock:InvokeModelWithResponseStream",
                 "bedrock:ListFoundationModels",


### PR DESCRIPTION
*Issue #89 

*Description of changes: Add `bedrock:GetInferenceProfile` Policy to API service role


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
