### PR TITLE
Update Dify image tag to version 1.10.1-fix.1 to avoid React2Shell

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -9,7 +9,7 @@ export const props: EnvironmentProps = {
   awsRegion: 'us-west-2',
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
-  difyImageTag: '1.10.1',
+  difyImageTag: '1.10.1-fix.1',
   // Set plugin-daemon version to stable release
   difyPluginDaemonImageTag: '0.4.1-local',
 


### PR DESCRIPTION
*Description of changes:*

it contains fix for [React2Shell](https://github.com/advisories/GHSA-fv66-9v8q-g76r)

- https://github.com/langgenius/dify/releases/tag/1.10.1-fix.1
- https://github.com/langgenius/dify/compare/1.10.1...1.10.1-fix.1
  - https://github.com/langgenius/dify/pull/29105
  - https://github.com/langgenius/dify/pull/29121

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
