### PR TITLE
Update Aurora PostgreSQL to v15.10

### DIFF
--- a/lib/constructs/postgres.ts
+++ b/lib/constructs/postgres.ts
@@ -38,7 +38,7 @@ export class Postgres extends Construct implements IConnectable {
 
     const { vpc } = props;
     const engine = rds.DatabaseClusterEngine.auroraPostgres({
-      version: rds.AuroraPostgresEngineVersion.VER_15_7,
+      version: rds.AuroraPostgresEngineVersion.VER_15_10,
     });
 
     const cluster = new rds.DatabaseCluster(this, 'Cluster', {

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -3237,7 +3237,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "DatabaseName": "main",
         "EnableHttpEndpoint": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.7",
+        "EngineVersion": "15.10",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -2558,7 +2558,7 @@ exports[`Snapshot test 1`] = `
         "DatabaseName": "main",
         "EnableHttpEndpoint": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.7",
+        "EngineVersion": "15.10",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -2560,7 +2560,7 @@ exports[`Snapshot test 1`] = `
         "DatabaseName": "main",
         "EnableHttpEndpoint": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.7",
+        "EngineVersion": "15.10",
         "MasterUserPassword": {
           "Fn::Join": [
             "",


### PR DESCRIPTION
Aurora PostgreSQL v15.7 reached the end of standard support in November 2025.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/aurorapostgresql-release-calendar.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
