### PR TITLE
confirm Dify can now scale out

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ The below are the list of configurable parameters and their default values:
         2. web: 256vCPU / 512MB
     2. Desired Count
         1. 1 task for each service
-        2. Currently the count of api service should be fixed to 1, because Dify plugin-daemon does not support scaling out well (See [dify-plugin-daemon#390](https://github.com/langgenius/dify-plugin-daemon/issues/390)). 
 2. ElastiCache ([redis.ts](./lib/constructs/redis.ts))
     1. Node Type: `cache.t4g.micro`
     2. Node Count: 1

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -9,9 +9,9 @@ export const props: EnvironmentProps = {
   awsRegion: 'us-west-2',
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
-  difyImageTag: '1.11.1',
+  difyImageTag: '1.11.4',
   // Set plugin-daemon version to stable release
-  difyPluginDaemonImageTag: '0.5.1-local',
+  difyPluginDaemonImageTag: '0.5.2-local',
 
   // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -434,6 +434,7 @@ export class ApiService extends Construct {
       ],
       enableExecuteCommand: true,
       minHealthyPercent: 100,
+      // desiredCount: 3, // set this for scaling out (default: 1)
     });
 
     postgres.connections.allowDefaultPortFrom(service);


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*


According to [this comment](https://github.com/langgenius/dify-plugin-daemon/issues/390#issuecomment-3732922871), Dify plugin-daemon can now simply scale out. I confirmed it works and updated the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
