### PR TITLE
fix: add missing ALB listener rules for MCP server endpoints

### DIFF
--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -442,6 +442,11 @@ export class ApiService extends Construct {
 
     const paths = ['/console/api', '/api', '/v1', '/files', '/triggers'];
     alb.addEcsService('Api', service, port, '/health', [...paths, ...paths.map((p) => `${p}/*`)]);
+
+    // Because maximum of condition is 5
+    const mcpPaths = ['/mcp', '/.well-known'];
+    alb.addEcsService('MCPServer', service, port, '/health', [...mcpPaths.map((p) => `${p}/*`)]);
+
     alb.addEcsService(
       'Extension',
       service.loadBalancerTarget({ containerName: 'PluginDaemon', containerPort: pluginDaemonPort }),

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -947,6 +947,34 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
+        "Priority": 4,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbListenerMCPServer0Rule5533A3CC": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroupInternal2D5EC26E",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/mcp/*",
+                "/.well-known/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
         "Priority": 3,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
@@ -974,9 +1002,37 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 4,
+        "Priority": 5,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbMCPServerTargetGroupInternal2D5EC26E": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 20,
+        "HealthCheckPath": "/health",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5001,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 6,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "AlbSecurityGroup433229ED": {
       "Properties": {
@@ -1224,6 +1280,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
         "AlbListenerExtension0Rule76BF40E2",
+        "AlbListenerMCPServer0Rule5533A3CC",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -1259,6 +1316,13 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroupInternal2EB9930E",
+            },
+          },
+          {
+            "ContainerName": "Main",
+            "ContainerPort": 5001,
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroupInternal2D5EC26E",
             },
           },
           {

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -564,6 +564,34 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
+        "Priority": 4,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbListenerMCPServer0Rule5533A3CC": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroup12703324",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/mcp/*",
+                "/.well-known/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
         "Priority": 3,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
@@ -591,9 +619,37 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 4,
+        "Priority": 5,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbMCPServerTargetGroup12703324": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/health",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5001,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 10,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "AlbSecurityGroup433229ED": {
       "Properties": {
@@ -809,6 +865,7 @@ exports[`Snapshot test 1`] = `
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
         "AlbListenerExtension0Rule76BF40E2",
+        "AlbListenerMCPServer0Rule5533A3CC",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -844,6 +901,13 @@ exports[`Snapshot test 1`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroup4B6AF19C",
+            },
+          },
+          {
+            "ContainerName": "Main",
+            "ContainerPort": 5001,
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroup12703324",
             },
           },
           {

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -611,6 +611,34 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
+        "Priority": 4,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbListenerMCPServer0Rule5533A3CC": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroup12703324",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "/mcp/*",
+                "/.well-known/*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "AlbListener318AEEBA",
+        },
         "Priority": 3,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
@@ -638,9 +666,37 @@ exports[`Snapshot test 1`] = `
         "ListenerArn": {
           "Ref": "AlbListener318AEEBA",
         },
-        "Priority": 4,
+        "Priority": 5,
       },
       "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "AlbMCPServerTargetGroup12703324": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/health",
+        "HealthyThresholdCount": 2,
+        "Matcher": {
+          "HttpCode": "200-299,307",
+        },
+        "Port": 5001,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "10",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 10,
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "AlbSecurityGroup433229ED": {
       "Properties": {
@@ -856,6 +912,7 @@ exports[`Snapshot test 1`] = `
         "AlbListenerApi0Rule033B7A48",
         "AlbListenerApi1RuleDF535F10",
         "AlbListenerExtension0Rule76BF40E2",
+        "AlbListenerMCPServer0Rule5533A3CC",
         "ApiServiceTaskTaskRoleDefaultPolicy982AD2DC",
         "ApiServiceTaskTaskRole06F87EBE",
       ],
@@ -891,6 +948,13 @@ exports[`Snapshot test 1`] = `
             "ContainerPort": 5001,
             "TargetGroupArn": {
               "Ref": "AlbApiTargetGroup4B6AF19C",
+            },
+          },
+          {
+            "ContainerName": "Main",
+            "ContainerPort": 5001,
+            "TargetGroupArn": {
+              "Ref": "AlbMCPServerTargetGroup12703324",
             },
           },
           {


### PR DESCRIPTION
Add /mcp/* and /.well-known/* path routing rules to the ALB for the Dify API service. These paths are registered as a separate listener rule (MCPServer) because ALB conditions have a maximum of 5 values per rule, and the existing API paths already use that limit.

Updates CDK snapshots to reflect the new target group and listener rule.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
