### PR TITLE
fix: disable CloudFront error caching for 404 responses (#111)

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -9,9 +9,9 @@ export const props: EnvironmentProps = {
   awsRegion: 'us-west-2',
   awsAccount: process.env.CDK_DEFAULT_ACCOUNT!,
   // Set Dify version
-  difyImageTag: '1.11.4',
+  difyImageTag: '1.13.3',
   // Set plugin-daemon version to stable release
-  difyPluginDaemonImageTag: '0.5.2-local',
+  difyPluginDaemonImageTag: '0.5.3-local',
 
   // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,

--- a/lib/constructs/alb-with-cloudfront.ts
+++ b/lib/constructs/alb-with-cloudfront.ts
@@ -93,6 +93,12 @@ export class AlbWithCloudFront extends Construct implements IAlb {
       },
       logBucket: accessLogBucket,
       logFilePrefix: 'dify-cloudfront/',
+      errorResponses: [
+        {
+          httpStatus: 404,
+          ttl: Duration.seconds(0),
+        },
+      ],
     });
     this.url = `https://${distribution.domainName}`;
 

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -708,6 +708,12 @@ exports[`Snapshot test (with CloudFront) 2`] = `
             "dify.example.com",
           ],
           "Comment": "Dify distribution (TestStack - us-west-2)",
+          "CustomErrorResponses": [
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 404,
+            },
+          ],
           "DefaultCacheBehavior": {
             "AllowedMethods": [
               "GET",


### PR DESCRIPTION
Fixes #111

CloudFront caches error responses (including 404) for 10 seconds by default (Error Caching Minimum TTL). This causes a **409 Conflict** when creating a new workflow in Dify v1.13.x with CloudFront enabled.

## Root Cause

When a user creates a new workflow:

1. `GET /workflows/draft` → 404 (draft does not exist yet) → **CloudFront caches this 404 for 10 seconds**
2. `POST /workflows/draft` → 200 (draft created successfully)
3. Recursive `GET /workflows/draft` → **CloudFront returns cached 404** instead of the actual draft
4. Frontend re-enters draft creation flow → `POST /workflows/draft` → **409 Conflict** (draft already exists, hash mismatch)

This issue does not occur with ALB-only deployments (confirmed by testing with `useCloudFront: false`).

## Changes

- **`lib/constructs/alb-with-cloudfront.ts`**: Add `errorResponses` to set `errorCachingMinTTL: 0` for 404 responses, preventing CloudFront from caching them.
- **`bin/cdk.ts`**: Bump default Dify version to 1.13.3 and plugin-daemon to 0.5.3-local, as the issue manifests with these versions.
- **Snapshot updated** accordingly.

## Testing

- All 3 test suites pass (3 tests, 4 snapshots)
- `cdk synth` generates correct CloudFormation template with `CustomErrorResponses`
- Verified on live CloudFront environment: workflow creation succeeds without 409

## Backward Compatibility

This change is safe for all Dify versions. Setting `errorCachingMinTTL: 0` for 404 only affects cache behavior — it does not modify the response itself. Older versions benefit from the same fix as they use the same workflow initialization flow.