### PR TITLE
update difyPluginDaemonImageTag to v0.5.5-local

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -11,7 +11,7 @@ export const props: EnvironmentProps = {
   // Set Dify version
   difyImageTag: '1.13.3',
   // Set plugin-daemon version to stable release
-  difyPluginDaemonImageTag: '0.5.3-local',
+  difyPluginDaemonImageTag: '0.5.5-local',
 
   // uncomment the below options for less expensive configuration:
   // isRedisMultiAz: false,


### PR DESCRIPTION
# DifyOnAwsStack Plugin Upload Incident

## Root Causes

### Cause 1: API contract bug between dify-api and dify-plugin-daemon

- The `DecodePluginFromIdentifier` endpoint in `dify-plugin-daemon:0.5.3-local` was implemented to read `plugin_unique_identifier` from the **JSON body** of GET requests.
- `dify-api:1.13.3` had already been patched to send this parameter as a **query string** instead.
- Since the HTTP specification states GET requests should not carry a semantic body, intermediaries (proxies / HTTP libraries) discarded the body. As a result, the plugin-daemon treated the required field as empty and returned `400 Bad Request`.
- The UI displayed "Internal Server Error" because Flask wrapped the resulting `HTTPStatusError` as a 500 response.

Related official fixes:
- [langgenius/dify-plugin-daemon#593](https://github.com/langgenius/dify-plugin-daemon/pull/593) (included in v0.5.5)
- [langgenius/dify#31697](https://github.com/langgenius/dify/pull/31697) (already included in v1.13.3)

### Cause 2: Bedrock plugin SDK compatibility issue

- The bundled `dify-plugin` SDK in `langgenius/bedrock:0.0.59` was out of sync with the SDK version the plugin code required.
- Startup failed with `ImportError: cannot import name 'MultiModalContent' from 'dify_plugin.entities.model.text_embedding'`, so the Bedrock runtime never started.
- Consequently, chat requests hit `no available node, plugin runtime not found` whenever the Bedrock LLM was invoked.

---

## Remediation

### Fix 1: Upgrade plugin-daemon to 0.5.5 or later

Update the relevant section in CDK code (`lib/constructs/dify-services/api.ts` or `environment-props.ts`):

```typescript
// Before
pluginDaemonImageTag: '0.5.3-local',

// After
pluginDaemonImageTag: '0.5.5-local',
```

Apply with `cdk deploy`.

> **Note**: Starting from 0.5.6, automatic DB migration was split out into a separate command. For the smallest-risk upgrade path, 0.5.5 is the optimal choice.

### Fix 2: Reinstall the Bedrock plugin at the latest version

From the Dify Web UI:

1. Open the "Plugin Management" screen.
2. Uninstall `langgenius/bedrock`.
3. Reinstall **the latest Bedrock plugin** from the Marketplace.

The reinstall rebuilds the `.venv`, which resolves a compatible `dify-plugin` SDK.

---

## Final Configuration

| Component | Before | After |
|---|---|---|
| `dify-api` | 1.13.3 | 1.13.3 (unchanged) |
| `dify-plugin-daemon` | 0.5.3-local | **0.5.5-local** |
| `langgenius/bedrock` | 0.0.59 | **latest** |
