### PR TITLE
chore(deps): bump aws-cdk CLI to 2.1135.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "20.12.7",
-        "aws-cdk": "^2.1105.0",
+        "aws-cdk": "^2.1135.0",
         "esbuild": "^0.28.1",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
@@ -1718,9 +1718,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1108.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1108.0.tgz",
-      "integrity": "sha512-FHnyhnYZoRc2W0C9mNzhNn6fO2vH4xNINsKfJaA7AFDuymgQ39JhEnrM4AHaoikIBqXYeNLWElvvkusY9l3ulw==",
+      "version": "2.1135.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.0.tgz",
+      "integrity": "sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "20.12.7",
-    "aws-cdk": "^2.1105.0",
+    "aws-cdk": "^2.1135.0",
     "esbuild": "^0.28.1",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",


### PR DESCRIPTION
## What

Bumps the `aws-cdk` (CDK CLI) devDependency from 2.1108.0 to 2.1135.0.

`package.json` goes from `^2.1105.0` to `^2.1135.0`; the rest is the lockfile.

## Why

The pinned CDK CLI reads cloud assembly schema up to `53.x.x` only, while
`aws-cdk-lib` 2.246.0 and later emit schema `54.0.0`. As soon as the library is
updated, the `npx cdk synth` step in the Build workflow fails:

```
This CDK CLI is not compatible with the CDK library used by your application.
(Cloud assembly schema version mismatch: Maximum schema version supported is
53.x.x, but found 54.0.0. You need at least CLI version 2.1127.0 to read this
manifest.)
```

This is currently latent in #123 (aws-cdk-lib 2.245.0 -> 2.260.0). That PR looks
green, but only CodeQL ran on it: its last commit was pushed by the
`update_snaphost.yml` workflow using `GITHUB_TOKEN`, and such pushes do not
re-trigger workflows, so `Build-and-Test-CDK` never ran against it. Merging #123
as-is would turn `main` red.

Landing the CLI bump first keeps `main` green through the whole sequence. The CLI
is backward compatible, so it works with the current `aws-cdk-lib` 2.245.0 as
well as with 2.260.0.

## Verification

Locally on top of `main` (45df910), with only this change applied:

- `npm run build` — pass
- `npm run format:check` — pass
- `npm run test` — 3 suites / 3 tests / 4 snapshots pass, no snapshot updates needed
- `npx cdk synth` — pass (fails without this change once aws-cdk-lib is bumped)

Also verified the combination of this change with #123 merged in: build,
format:check, test and `cdk synth` all pass.

## Follow-up

After this lands, #123 can be merged safely.