### PR TITLE
chore: align Node.js versions on 24 (Active LTS) and drop EOL Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - run: |
           npm ci
           npm run build

--- a/.github/workflows/update_snaphost.yml
+++ b/.github/workflows/update_snaphost.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: |
           npm ci
           npm run test -- -u

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For a quick and convenient deployment, you can use the one-click deployment opti
 ## Prerequisites
 You must have the following dependencies installed to deploy this app:
 
-* [Node.js](https://nodejs.org/en/download/) (v20 or newer)
+* [Node.js](https://nodejs.org/en/download/) (v22 or newer)
 * [Docker](https://docs.docker.com/get-docker/)
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and IAM profile with Administrator policy
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 22
+      nodejs: 24
   pre_build:
     commands:
       - echo Installing source NPM dependencies...

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "20.12.7",
+        "@types/node": "24.13.3",
         "aws-cdk": "^2.1135.0",
         "esbuild": "^0.28.1",
         "jest": "^29.7.0",
@@ -1578,13 +1578,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4809,9 +4809,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "20.12.7",
+    "@types/node": "24.13.3",
     "aws-cdk": "^2.1135.0",
     "esbuild": "^0.28.1",
     "jest": "^29.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": [
-      "es2020",
+      "es2022",
       "dom"
     ],
     "declaration": true,


### PR DESCRIPTION
## Problem

Node.js was referenced in five places with three different versions, and one of them is past end-of-life:

| Location | Version | Status |
| --- | --- | --- |
| `.github/workflows/build.yml` | `22.x` | Maintenance LTS |
| `.github/workflows/update_snaphost.yml` | `20.x` | **EOL since 2026-04-30** |
| `package.json` (`@types/node`) | `20.12.7` | mismatched with the Build workflow |
| `buildspec.yml` (CodeBuild runtime) | `22` | Maintenance LTS |
| `README.md` (documented requirement) | `v20 or newer` | floor is an EOL version |

The snapshot updater was regenerating committed snapshots on an unsupported runtime.

## Change

Align everything on Node.js 24, which is Active LTS until 2028-04-30 per the
[official release schedule](https://github.com/nodejs/Release/blob/main/schedule.json).

- `build.yml` / `update_snaphost.yml`: `node-version` -> `24.x`
- `buildspec.yml`: `nodejs: 24`
- `@types/node`: `20.12.7` -> `24.13.3` (pulls `undici-types` 5.26.5 -> 6.21.0)
- `tsconfig.json`: `lib` `es2020` -> `es2022`
- `README.md`: documented requirement `v20` -> `v22 or newer`

### Why tsconfig changes

`@types/node` 24 no longer declares `Array.prototype.at` itself and defers to the
TypeScript `lib`, so bumping it surfaced a pre-existing gap:

```
lib/constructs/postgres.ts(124,64): error TS2550: Property 'at' does not exist on
type 'AwsCustomResource[]'. Try changing the 'lib' compiler option to 'es2022' or later.
```

`postgres.ts` uses `this.queries.at(-1)`, which is an ES2022 API. Only `lib` is
raised; `target` stays at `ES2020` because this is about the ambient library set,
not the emitted syntax. Node 22 and 24 both provide ES2022 APIs.

### Why CodeBuild needs no image change

`bin/deploy.ts` uses `LinuxBuildImage.STANDARD_7_0` (Ubuntu 22.04 standard:7.0),
which [supports the nodejs 24 runtime](https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html).
No change to `bin/deploy.ts` and no infrastructure diff.

### Why the README floor is 22, not 24

Node 22 still builds and synthesizes fine (verified below), so the floor is only
raised past the EOL version rather than forcing consumers onto 24.

## Verification

Local, on both Node 24.19.0 and Node 22.14.0:

| | Node 24.19.0 | Node 22.14.0 |
| --- | --- | --- |
| `npm run build` | pass | pass |
| `npm run format:check` | pass | pass |
| `npm run test` | 3 suites / 4 snapshots pass | 3 suites / 4 snapshots pass |
| `npx cdk synth` | pass | pass |
| snapshot diff | none | none |

Snapshots are unchanged, so no synthesized template is affected.

Additionally deployed to a real environment in `ap-northeast-1` (existing
`DifyOnAwsStack`) to confirm the change produces no CloudFormation drift of its
own. The stack reached `UPDATE_COMPLETE` and both ECS services returned to a
steady state.