### PR TITLE
fix: raise api service task memory to 4096 MiB and make task size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The below are the list of configurable parameters and their default values:
 
 1. ECS Task ([api.ts](./lib/constructs/dify-services/api.ts), [web.ts](./lib/constructs/dify-services/web.ts))
     1. Size
-        1. api/worker: 1024vCPU / 2048MB
+        1. api/worker: 1024vCPU / 4096MB (configurable via `apiServiceCpu` / `apiServiceMemoryLimitMiB`)
         2. web: 256vCPU / 512MB
     2. Desired Count
         1. 1 task for each service
@@ -306,13 +306,13 @@ The following table provides a sample cost breakdown for deploying this system i
 | --------------------| ----------------- | -------------------------------|
 | RDS Aurora | Postgres Serverless v2 (0 ACU) | $0 |
 | ElastiCache | Valkey t4g.micro | $9.2 |
-| ECS (Fargate) | Dify-web 1 task running 24/7 (256CPU) | $2.7 |
-| ECS (Fargate) | Dify-api/worker 1 task running 24/7 (1024CPU) | $10.7 |
+| ECS (Fargate) | Dify-web 1 task running 24/7 (256CPU / 512MB) | $2.7 |
+| ECS (Fargate) | Dify-api/worker 1 task running 24/7 (1024CPU / 4096MB) | $12.6 |
 | Application Load Balancer | ALB-hour per month | $17.5 |
 | VPC | NAT Instances t4g.nano x1 | $3.0 |
 | VPC | Public IP address x1 | $3.6 |
 | Secrets Manager | Secret x3 | $1.2 |
-| TOTAL | estimate per month | $47.9 |
+| TOTAL | estimate per month | $49.8 |
 
 Note that you have to pay LLM cost (e.g. Amazon Bedrock ) in addition to the above, which totally depends on your specific use case.
 

--- a/lib/constructs/dify-services/api.ts
+++ b/lib/constructs/dify-services/api.ts
@@ -41,6 +41,16 @@ export interface ApiServiceProps {
 
   autoMigration: boolean;
   useFargateSpot: boolean;
+
+  /**
+   * The amount of CPU units allocated to the task.
+   */
+  cpu: number;
+
+  /**
+   * The amount of memory (in MiB) allocated to the task.
+   */
+  memoryLimitMiB: number;
 }
 
 export class ApiService extends Construct {
@@ -53,8 +63,10 @@ export class ApiService extends Construct {
     const volumeName = 'sandbox';
 
     const taskDefinition = new FargateTaskDefinition(this, 'Task', {
-      cpu: 1024,
-      memoryLimitMiB: 2048, // We got OOM frequently when RAM=512MB
+      // The plugin-daemon container installs plugin dependencies and pre-compiles them on every
+      // task startup, which used to cause an OOM crash loop with the previous default (2048 MiB).
+      cpu: props.cpu,
+      memoryLimitMiB: props.memoryLimitMiB,
       runtimePlatform: { cpuArchitecture: CpuArchitecture.X86_64 },
       volumes: [
         {

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -36,6 +36,8 @@ export class DifyOnAwsStack extends cdk.Stack {
       internalAlb = false,
       useFargateSpot = false,
       subDomain = 'dify',
+      apiServiceCpu = 1024,
+      apiServiceMemoryLimitMiB = 4096,
     } = props;
 
     if (props.vpcId && (props.vpcIsolated != null || props.useNatInstance != null)) {
@@ -158,6 +160,8 @@ export class DifyOnAwsStack extends cdk.Stack {
       additionalEnvironmentVariables: props.additionalEnvironmentVariables,
       autoMigration: true,
       useFargateSpot,
+      cpu: apiServiceCpu,
+      memoryLimitMiB: apiServiceMemoryLimitMiB,
     });
 
     new WebService(this, 'WebService', {

--- a/lib/environment-props.ts
+++ b/lib/environment-props.ts
@@ -86,6 +86,28 @@ export interface EnvironmentProps {
   useFargateSpot?: boolean;
 
   /**
+   * The amount of CPU units allocated to the api service Fargate task.
+   * The task runs the api, worker, sandbox, and plugin-daemon containers.
+   *
+   * Must be a valid Fargate CPU value (e.g. 512, 1024, 2048, 4096).
+   * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+   * @default 1024
+   */
+  apiServiceCpu?: number;
+
+  /**
+   * The amount of memory (in MiB) allocated to the api service Fargate task.
+   * The plugin-daemon container consumes a large amount of memory when it installs
+   * plugin dependencies and pre-compiles them on task startup, so 2048 MiB is often
+   * not enough once you install plugins. Consider 8192 for plugin-heavy workloads.
+   *
+   * Must be a valid combination with {@link apiServiceCpu}.
+   * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+   * @default 4096
+   */
+  apiServiceMemoryLimitMiB?: number;
+
+  /**
    * The image tag to deploy the Dify container images (api and web).
    * The images are pulled from [here](https://hub.docker.com/u/langgenius).
    *

--- a/test/__snapshots__/dify-on-aws-cf.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-cf.test.ts.snap
@@ -2473,7 +2473,7 @@ exports[`Snapshot test (with CloudFront) 2`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws-closed-network.test.ts.snap
@@ -2127,7 +2127,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/test/__snapshots__/dify-on-aws.test.ts.snap
+++ b/test/__snapshots__/dify-on-aws.test.ts.snap
@@ -2109,7 +2109,7 @@ exports[`Snapshot test 1`] = `
           ],
         },
         "Family": "TestStackApiServiceTaskBFA8CBF7",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",


### PR DESCRIPTION
## Issue

Closes #119

## What happens today

The api service Fargate task is fixed at 1024 CPU / 2048 MiB, and it runs 6 containers sharing that single memory limit: `Main` (gunicorn, 7 gevent workers), `Worker`, `Sandbox`, `SandboxFileMount`, `PluginDaemon`, and `ExternalKnowledgeBaseAPI`.

`PluginDaemon` runs `uv pip install` and Python bytecode pre-compilation for **every installed plugin on each task startup**. Once a couple of plugins are installed, that startup work plus gunicorn booting its workers exceeds 2048 MiB, gunicorn workers exit with code 23 (memory allocation failure), and the task enters a crash loop. With no healthy target left, the ALB returns 504.

Observed with Dify 1.13.3 in ap-northeast-1: memory utilization sat at 97-99% of the 2048 MiB limit even in steady state. Related upstream report: langgenius/dify#27820.

Dify's own [Docker Compose prerequisites](https://docs.dify.ai/en/self-host/quick-start/docker-compose) ask for >= 2 cores / >= 4 GiB RAM.

## Changes

- Default api service task memory: **2048 -> 4096 MiB**. The root cause is memory, not CPU, so CPU stays at 1024 to keep the cost delta small.
- New optional properties in `EnvironmentProps`: `apiServiceCpu` (default 1024) and `apiServiceMemoryLimitMiB` (default 4096), so the task size can be tuned without editing constructs — 8192 MiB for plugin-heavy workloads, or back down to 2048 MiB for cost-sensitive deployments that do not use plugins.
- README: updated the task size in "Scaling out / Scaling up" and the Cost table.

## Cost impact

Fargate bills memory per GB-hour, so the api task line in the Cost table moves from $10.7 to about $12.6 / month (total $47.9 -> $49.8). The figure keeps the existing table's Fargate Spot basis: the same on-demand-to-Spot ratio that reproduces the current web ($2.7) and api ($10.7) rows, applied to 1 vCPU + 4 GB.

## Testing

- `npx tsc --noEmit` passes.
- `npx jest` — 3 suites pass. Snapshots regenerated on Node 24 (matching the version pinned in #126); the only diff is `Memory: "2048"` -> `"4096"` in the three stack snapshots.
- `npx prettier --check lib` passes.

Not verified: whether 4096 MiB is sufficient for very plugin-heavy installs, and whether CPU contention shows up separately once memory is no longer the bottleneck. The crash logs in #119 only evidence OOM. That is why the size is now configurable.
